### PR TITLE
release: onboarding flow v1.0.0

### DIFF
--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -84,7 +84,7 @@ export default async function LocaleLayout({ children, params }: Props) {
 
   return (
     <html lang={locale} suppressHydrationWarning>
-      <body style={{ backgroundColor: '#f6f6f6' }} suppressHydrationWarning>
+      <body className={dmSans.variable} style={{ backgroundColor: '#f6f6f6' }} suppressHydrationWarning>
         <ViewportHeightSetter />
         <Providers>
           <NextIntlClientProvider messages={messages}>

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -84,7 +84,7 @@ export default async function LocaleLayout({ children, params }: Props) {
 
   return (
     <html lang={locale} suppressHydrationWarning>
-      <body className={dmSans.variable} style={{ backgroundColor: '#f6f6f6' }} suppressHydrationWarning>
+      <body style={{ backgroundColor: '#f6f6f6' }} suppressHydrationWarning>
         <ViewportHeightSetter />
         <Providers>
           <NextIntlClientProvider messages={messages}>

--- a/apps/web/src/app/[locale]/onboarding/age/page.tsx
+++ b/apps/web/src/app/[locale]/onboarding/age/page.tsx
@@ -8,8 +8,8 @@ import { logger, transformError } from '@repo/shared/utils';
 import { Button } from '@web/components/ui/button';
 import { Select } from '@web/components/ui/select';
 import {
-  registerUser,
   Title,
+  registerUser,
   useBirthdateValidation,
   useOnboardingStore,
   type BirthDateSelection,
@@ -44,12 +44,14 @@ function AgePage() {
 
       try {
         const { nickname, birthDateSelection } = useOnboardingStore.getState();
-        const age = new Date().getFullYear() - parseInt(birthDateSelection.year, 10) + 1;
+        const koreanAge = new Date().getFullYear() - parseInt(birthDateSelection.year, 10) + 1;
 
-        logger.info('[Age Page] Submitting user:', { nickname, age });
+        logger.info('[Age Page] Submitting user:', { nickname, koreanAge });
 
-        const response = await registerUser({ chatNickname: nickname.trim(), age });
+        const response = await registerUser({ chatNickname: nickname, age: koreanAge });
+
         if (!response.success) {
+          toast.error(response.error?.message || '오류가 발생했습니다. 다시 시도해주세요.');
           return;
         }
 
@@ -57,6 +59,7 @@ function AgePage() {
       } catch (error) {
         const appError = transformError(error);
         logger.error('[Age Page] Submit error:', appError.toJSON());
+        toast.error('오류가 발생했습니다. 다시 시도해주세요.');
       } finally {
         setIsSubmitting(false);
       }
@@ -79,15 +82,15 @@ function AgePage() {
       </span>
 
       <form onSubmit={handleSubmit}>
-        <div className={styles.select}>
+        <div className={styles.selectContainer}>
           <Select
             onChange={handleDateChange}
             onValidityChange={setIsDateValid}
             onSelectionChange={handleSelectionChange}
             error={error ?? undefined}
             initialValue={birthDateSelection}
-          />
-        </div>
+            />
+        </div>  
 
         <Button
           type="submit"

--- a/apps/web/src/app/[locale]/onboarding/age/page.tsx
+++ b/apps/web/src/app/[locale]/onboarding/age/page.tsx
@@ -1,15 +1,15 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
 import { useCallback, useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 import { ROUTES } from '@repo/shared/constants';
 import { logger, transformError } from '@repo/shared/utils';
 import { Button } from '@web/components/ui/button';
 import { Select } from '@web/components/ui/select';
 import {
-  registerUser,
   Title,
+  registerUser,
   useBirthdateValidation,
   useOnboardingStore,
   type BirthDateSelection,
@@ -44,12 +44,14 @@ function AgePage() {
 
       try {
         const { nickname, birthDateSelection } = useOnboardingStore.getState();
-        const age = new Date().getFullYear() - parseInt(birthDateSelection.year, 10) + 1;
+        const koreanAge = new Date().getFullYear() - parseInt(birthDateSelection.year, 10) + 1;
 
-        logger.info('[Age Page] Submitting user:', { nickname, age });
+        logger.info('[Age Page] Submitting user:', { nickname, koreanAge });
 
-        const response = await registerUser({ chatNickname: nickname.trim(), age });
+        const response = await registerUser({ chatNickname: nickname, age: koreanAge });
+
         if (!response.success) {
+          toast.error(response.error?.message || '오류가 발생했습니다. 다시 시도해주세요.');
           return;
         }
 
@@ -57,6 +59,7 @@ function AgePage() {
       } catch (error) {
         const appError = transformError(error);
         logger.error('[Age Page] Submit error:', appError.toJSON());
+        toast.error('오류가 발생했습니다. 다시 시도해주세요.');
       } finally {
         setIsSubmitting(false);
       }
@@ -79,15 +82,15 @@ function AgePage() {
       </span>
 
       <form onSubmit={handleSubmit}>
-        <div className={styles.select}>
+        <div className={styles.selectContainer}>
           <Select
             onChange={handleDateChange}
             onValidityChange={setIsDateValid}
             onSelectionChange={handleSelectionChange}
             error={error ?? undefined}
             initialValue={birthDateSelection}
-          />
-        </div>
+            />
+        </div>  
 
         <Button
           type="submit"

--- a/apps/web/src/app/[locale]/onboarding/age/page.tsx
+++ b/apps/web/src/app/[locale]/onboarding/age/page.tsx
@@ -1,18 +1,20 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
 import { useCallback, useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 import { ROUTES } from '@repo/shared/constants';
 import { logger, transformError } from '@repo/shared/utils';
 import { Button } from '@web/components/ui/button';
 import { Select } from '@web/components/ui/select';
+import { toast } from '@web/components/ui/toast';
+import { withAuth } from '@web/features/auth';
 import {
+  ERROR_MESSAGES,
   registerUser,
   Title,
   useBirthdateValidation,
   useOnboardingStore,
-  type BirthDateSelection,
 } from '@web/features/onboarding';
 
 import styles from '../onboarding.module.scss';
@@ -27,13 +29,6 @@ function AgePage() {
   const { birthDateSelection, error, handleDateChange, validateBirthdate } =
     useBirthdateValidation();
 
-  const handleSelectionChange = useCallback(
-    (selection: BirthDateSelection) => {
-      handleDateChange(selection);
-    },
-    [handleDateChange],
-  );
-
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault();
@@ -44,20 +39,22 @@ function AgePage() {
 
       try {
         const { nickname, birthDateSelection } = useOnboardingStore.getState();
-        const koreanAge = new Date().getFullYear() - parseInt(birthDateSelection.year, 10) + 1;
+        const age = new Date().getFullYear() - parseInt(birthDateSelection.year, 10) + 1;
 
-        logger.info('[Age Page] Submitting user:', { nickname, koreanAge });
+        logger.info('[Age Page] Submitting user:', { nickname, age });
 
-        const response = await registerUser({ chatNickname: nickname, age: koreanAge });
+        const response = await registerUser({ chatNickname: nickname, age });
 
         if (!response.success) {
+          toast.error(response.error?.message || ERROR_MESSAGES.GENERIC);
           return;
         }
 
-        router.push(ROUTES.ONBOARDING_INTERESTS);
+        router.push(ROUTES.ONBOARDING_PREFERENCES);
       } catch (error) {
         const appError = transformError(error);
         logger.error('[Age Page] Submit error:', appError.toJSON());
+        toast.error(ERROR_MESSAGES.GENERIC);
       } finally {
         setIsSubmitting(false);
       }
@@ -84,7 +81,7 @@ function AgePage() {
           <Select
             onChange={handleDateChange}
             onValidityChange={setIsDateValid}
-            onSelectionChange={handleSelectionChange}
+            onSelectionChange={handleDateChange}
             error={error ?? undefined}
             initialValue={birthDateSelection}
           />
@@ -96,9 +93,6 @@ function AgePage() {
           isLoading={isSubmitting}
           disabled={isSubmitting}
           className={styles.submit}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && !isSubmitting) handleSubmit(e);
-          }}
         >
           다음
         </Button>
@@ -107,4 +101,4 @@ function AgePage() {
   );
 }
 
-export default AgePage;
+export default withAuth(AgePage);

--- a/apps/web/src/app/[locale]/onboarding/age/page.tsx
+++ b/apps/web/src/app/[locale]/onboarding/age/page.tsx
@@ -8,8 +8,8 @@ import { logger, transformError } from '@repo/shared/utils';
 import { Button } from '@web/components/ui/button';
 import { Select } from '@web/components/ui/select';
 import {
-  Title,
   registerUser,
+  Title,
   useBirthdateValidation,
   useOnboardingStore,
   type BirthDateSelection,
@@ -89,8 +89,8 @@ function AgePage() {
             onSelectionChange={handleSelectionChange}
             error={error ?? undefined}
             initialValue={birthDateSelection}
-            />
-        </div>  
+          />
+        </div>
 
         <Button
           type="submit"

--- a/apps/web/src/app/[locale]/onboarding/age/page.tsx
+++ b/apps/web/src/app/[locale]/onboarding/age/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useCallback, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useCallback, useState } from 'react';
 
 import { ROUTES } from '@repo/shared/constants';
 import { logger, transformError } from '@repo/shared/utils';
@@ -51,7 +51,6 @@ function AgePage() {
         const response = await registerUser({ chatNickname: nickname, age: koreanAge });
 
         if (!response.success) {
-          toast.error(response.error?.message || '오류가 발생했습니다. 다시 시도해주세요.');
           return;
         }
 
@@ -59,7 +58,6 @@ function AgePage() {
       } catch (error) {
         const appError = transformError(error);
         logger.error('[Age Page] Submit error:', appError.toJSON());
-        toast.error('오류가 발생했습니다. 다시 시도해주세요.');
       } finally {
         setIsSubmitting(false);
       }

--- a/apps/web/src/app/[locale]/onboarding/age/page.tsx
+++ b/apps/web/src/app/[locale]/onboarding/age/page.tsx
@@ -44,14 +44,12 @@ function AgePage() {
 
       try {
         const { nickname, birthDateSelection } = useOnboardingStore.getState();
-        const koreanAge = new Date().getFullYear() - parseInt(birthDateSelection.year, 10) + 1;
+        const age = new Date().getFullYear() - parseInt(birthDateSelection.year, 10) + 1;
 
-        logger.info('[Age Page] Submitting user:', { nickname, koreanAge });
+        logger.info('[Age Page] Submitting user:', { nickname, age });
 
-        const response = await registerUser({ chatNickname: nickname, age: koreanAge });
-
+        const response = await registerUser({ chatNickname: nickname.trim(), age });
         if (!response.success) {
-          toast.error(response.error?.message || '오류가 발생했습니다. 다시 시도해주세요.');
           return;
         }
 
@@ -59,7 +57,6 @@ function AgePage() {
       } catch (error) {
         const appError = transformError(error);
         logger.error('[Age Page] Submit error:', appError.toJSON());
-        toast.error('오류가 발생했습니다. 다시 시도해주세요.');
       } finally {
         setIsSubmitting(false);
       }
@@ -82,7 +79,7 @@ function AgePage() {
       </span>
 
       <form onSubmit={handleSubmit}>
-        <div className={styles.selectContainer}>
+        <div className={styles.select}>
           <Select
             onChange={handleDateChange}
             onValidityChange={setIsDateValid}

--- a/apps/web/src/app/[locale]/onboarding/age/page.tsx
+++ b/apps/web/src/app/[locale]/onboarding/age/page.tsx
@@ -44,12 +44,11 @@ function AgePage() {
 
       try {
         const { nickname, birthDateSelection } = useOnboardingStore.getState();
-        const koreanAge = new Date().getFullYear() - parseInt(birthDateSelection.year, 10) + 1;
+        const age = new Date().getFullYear() - parseInt(birthDateSelection.year, 10) + 1;
 
-        logger.info('[Age Page] Submitting user:', { nickname, koreanAge });
+        logger.info('[Age Page] Submitting user:', { nickname, age });
 
-        const response = await registerUser({ chatNickname: nickname, age: koreanAge });
-
+        const response = await registerUser({ chatNickname: nickname.trim(), age });
         if (!response.success) {
           return;
         }
@@ -80,7 +79,7 @@ function AgePage() {
       </span>
 
       <form onSubmit={handleSubmit}>
-        <div className={styles.selectContainer}>
+        <div className={styles.select}>
           <Select
             onChange={handleDateChange}
             onValidityChange={setIsDateValid}

--- a/apps/web/src/app/[locale]/onboarding/name/page.tsx
+++ b/apps/web/src/app/[locale]/onboarding/name/page.tsx
@@ -47,6 +47,7 @@ function NamePage() {
 
       <form className={styles.form} onSubmit={handleSubmit}>
         <Input
+          id="nickname"
           variant="outline"
           value={name}
           onChange={(e) => handleNicknameChange(e.target.value)}
@@ -54,7 +55,16 @@ function NamePage() {
           inputClassName={styles.input}
           size="md"
           error={error ?? undefined}
+          aria-label="닉네임"
+          aria-required="true"
+          aria-invalid={!!error}
+          aria-describedby={error ? 'nickname-error' : undefined}
         />
+        {error && (
+          <span id="nickname-error" role="alert" className={styles.errorHint}>
+            {error}
+          </span>
+        )}
 
         <span>
           상품 리뷰 등에 사용될 {name}님의 아이디는 {randomNickname}(으)로 할게요.
@@ -62,16 +72,7 @@ function NamePage() {
           아이디는 추후에 설정에서 수정할 수 있어요.
         </span>
 
-        <Button
-          type="submit"
-          colorScheme="pink"
-          className={styles.submit}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              handleSubmit(e);
-            }
-          }}
-        >
+        <Button type="submit" colorScheme="pink" className={styles.submit}>
           다음
         </Button>
       </form>

--- a/apps/web/src/app/[locale]/onboarding/onboarding.module.scss
+++ b/apps/web/src/app/[locale]/onboarding/onboarding.module.scss
@@ -7,7 +7,7 @@ $toggle-size: 1.25rem;
 $border-width: 2px;
 
 .container {
-  @include full-screen-container;
+  @include full-screen-scrollable;
   @include hide-scrollbar;
   @include safe-area-inset(padding, all);
   @include extend-background-to-status-bar($gray-50);
@@ -22,7 +22,7 @@ $border-width: 2px;
 
 .content {
   @include flex-column;
-  @include size(100%, 100%);
+  width: 100%;
   gap: 1.5rem;
   padding-bottom: calc(4rem + env(safe-area-inset-bottom));
 
@@ -30,25 +30,39 @@ $border-width: 2px;
     width: 88%;
   }
 
-  .submit {
-    position: fixed;
-    bottom: calc(1.5rem + env(safe-area-inset-bottom));
-    left: 50%;
+  %submit-base {
     width: 10%;
-    transform: translateX(-50%);
     color: black !important;
     font-size: $font-size-lg;
     font-weight: $font-weight-medium;
     border-radius: 2rem !important;
     box-shadow: $box-shadow-md;
     z-index: 10;
-
-    &:active {
-      transform: translateX(-50%) translateY(1px) !important;
-    }
+    bottom: calc(1.5rem + env(safe-area-inset-bottom));
 
     @include respond(mobile) {
       width: 36%;
+    }
+  }
+
+  .submit {
+    @extend %submit-base;
+    position: fixed;
+    left: 50%;
+    transform: translateX(-50%);
+
+    &:active {
+      transform: translateX(-50%) translateY(1px);
+    }
+  }
+
+  .submitSticky {
+    @extend %submit-base;
+    position: sticky;
+    align-self: center;
+
+    &:active {
+      transform: translateY(1px);
     }
   }
 }
@@ -85,7 +99,7 @@ $border-width: 2px;
 
 .input {
   border-radius: 0.8rem !important;
-  border-color: #bcbbbb;
+  border-color: $gray-400;
   box-shadow: $box-shadow-md;
 }
 
@@ -95,5 +109,91 @@ $border-width: 2px;
 
   @include respond(mobile) {
     font-weight: $font-weight-light;
+  }
+}
+
+.category {
+  @include flex-column;
+  gap: $spacing-2;
+}
+
+.label {
+  font-weight: $font-weight-regular;
+  color: $red;
+  @include text-responsive($font-size-lg, $font-size-lg, $font-size-xl);
+}
+
+.options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-2;
+}
+
+.selectionGroup {
+  button {
+    padding: 0.3rem 0.8rem;
+    border-radius: $radius-4xl;
+    color: $black !important;
+    font-weight: $font-weight-regular;
+    border-color: $gray-400 !important;
+    transition:
+      transform 0.15s ease,
+      background-color 0.35s ease,
+      border-color 0.35s ease;
+
+    &:active {
+      transform: scale(0.95);
+    }
+
+    &[class*='button--selected'] {
+      border-color: $gray-400 !important;
+    }
+  }
+
+  @include respond(mobile) {
+    button {
+      min-height: 0;
+      font-weight: $font-weight-light;
+
+      &[class*='button--selected'] {
+        font-weight: $font-weight-light;
+      }
+    }
+  }
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+    max-height: 500px;
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-8px);
+    max-height: 0;
+  }
+}
+
+.animatedSection {
+  @include flex-column;
+  gap: calc($spacing-6 / 2);
+  overflow: hidden;
+  animation: slideDown 0.25s ease forwards;
+
+  &.exiting {
+    animation: slideUp 0.2s ease forwards;
+    pointer-events: none;
   }
 }

--- a/apps/web/src/app/[locale]/onboarding/page.tsx
+++ b/apps/web/src/app/[locale]/onboarding/page.tsx
@@ -21,7 +21,7 @@ function OnboardingPage() {
 
     // early return if all steps are completed
     if (nickname && age) {
-      router.replace(ROUTES.ONBOARDING_INTERESTS);
+      router.replace(ROUTES.ONBOARDING_PREFERENCES);
       return;
     }
 

--- a/apps/web/src/app/[locale]/onboarding/preferences/page.tsx
+++ b/apps/web/src/app/[locale]/onboarding/preferences/page.tsx
@@ -1,17 +1,145 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
+import { useCallback, useState } from 'react';
+
+import { ROUTES } from '@repo/shared/constants';
+import { logger, transformError } from '@repo/shared/utils';
 import { Button } from '@web/components/ui/button';
+import { SelectionGroup } from '@web/components/ui/selection-group';
+import { toast } from '@web/components/ui/toast';
+import { withAuth } from '@web/features/auth';
 import {
   CategorySection,
-  HEALTH_CARE_INTERESTS,
+  COMMERCE_PREFERENCES,
+  COMMUNITY_PREFERENCES,
+  ERROR_MESSAGES,
+  FEMININE_CARE_PREFERENCES,
+  GYNECOLOGY_PREFERENCES,
+  HEALTH_CARE_PREFERENCES,
+  HOSPITAL_PRIORITIES,
   Title,
+  useOnboardingNavigationGuard,
   useOnboardingStore,
+  type PreferencesState,
 } from '@web/features/onboarding';
+import { useAnimatedSection } from '@web/features/onboarding/hooks/use-animated-section';
+import { toggle, toOptions } from '@web/features/onboarding/utils/preferences.utils';
 
 import styles from '../onboarding.module.scss';
 
+const HOSPITAL_VISIT_OPTIONS = [
+  { key: 'true', display: '네, 가봤어요' },
+  { key: 'false', display: '아니요, 가본 적 없어요' },
+];
+
 function PreferencesPage() {
-  const { nickname } = useOnboardingStore();
+  const router = useRouter();
+  const nickname = useOnboardingStore((s) => s.nickname);
+  const age = useOnboardingStore((s) => s.age);
+
+  useOnboardingNavigationGuard({ requireNickname: true, requireAge: true, nickname, age });
+
+  const submitPreferences = useOnboardingStore((s) => s.submitPreferences);
+  const setPreferences = useOnboardingStore((s) => s.setPreferences);
+  const {
+    healthCareInterests,
+    gynecologyInterests,
+    hasVisited,
+    hospitalPriorities,
+    communityInterests,
+    commerceInterests,
+    productCategories,
+  } = useOnboardingStore((s) => s.preferences);
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const showGynecologySection = healthCareInterests.includes('GYNECOLOGY_QNA');
+  const showHospitalSection = healthCareInterests.includes('FIND_HOSPITAL');
+  const showProductSection = commerceInterests.includes('PRODUCT_SEARCH');
+
+  const gynecology = useAnimatedSection(showGynecologySection);
+  const hospital = useAnimatedSection(showHospitalSection);
+  const product = useAnimatedSection(showProductSection);
+
+  const isSubmitEnabled =
+    healthCareInterests.length > 0 && communityInterests.length > 0 && commerceInterests.length > 0;
+
+  const completionCount = [
+    healthCareInterests.length > 0,
+    communityInterests.length > 0,
+    commerceInterests.length > 0,
+  ].filter(Boolean).length;
+
+  const submitBgColor = `rgba(255, 106, 106, ${completionCount / 3})`;
+
+  const handleHealthCareSelect = useCallback(
+    (key: string) => {
+      const next = toggle(healthCareInterests, key);
+      const update: Partial<PreferencesState> = { healthCareInterests: next };
+
+      if (key === 'GYNECOLOGY_QNA' && !next.includes('GYNECOLOGY_QNA')) {
+        update.gynecologyInterests = [];
+      }
+      if (key === 'FIND_HOSPITAL' && !next.includes('FIND_HOSPITAL')) {
+        update.hasVisited = null;
+        update.hospitalPriorities = [];
+      }
+
+      setPreferences(update);
+    },
+    [healthCareInterests, setPreferences],
+  );
+
+  const handleCommerceSelect = useCallback(
+    (key: string) => {
+      const next = toggle(commerceInterests, key);
+      const update: Partial<PreferencesState> = { commerceInterests: next };
+
+      if (key === 'PRODUCT_SEARCH' && !next.includes('PRODUCT_SEARCH')) {
+        update.productCategories = [];
+      }
+
+      setPreferences(update);
+    },
+    [commerceInterests, setPreferences],
+  );
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!isSubmitEnabled) return;
+
+      setIsSubmitting(true);
+      try {
+        const { preferences } = useOnboardingStore.getState();
+        await submitPreferences({
+          healthCareInterests: preferences.healthCareInterests,
+          gynecologyInterests: preferences.gynecologyInterests,
+          // When FIND_HOSPITAL is not selected, the hospital section is never shown;
+          // send false as the server's expected default for "not applicable".
+          hasVisited: preferences.healthCareInterests.includes('FIND_HOSPITAL')
+            ? preferences.hasVisited!
+            : false,
+          hospitalPriorities: preferences.hospitalPriorities,
+          communityInterests: preferences.communityInterests,
+          commerceInterests: preferences.commerceInterests,
+          productCategories: preferences.productCategories,
+        });
+
+        logger.info('[Preferences Page] Preferences registered successfully');
+        toast.success(`환영합니다. ${nickname}님!`);
+        router.push(ROUTES.CHAT);
+      } catch (error) {
+        const appError = transformError(error);
+        logger.error('[Preferences Page] Submit error:', appError.toJSON());
+        toast.error(ERROR_MESSAGES.GENERIC);
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [isSubmitEnabled, nickname, submitPreferences, router],
+  );
 
   return (
     <section className={styles.content}>
@@ -22,26 +150,131 @@ function PreferencesPage() {
       </Title>
       <span className={styles.description}>많으면 많을수록 좋아요!</span>
 
-      <form>
-        <CategorySection label="HealthCare">
-          <div className={styles.options}>
-            {HEALTH_CARE_INTERESTS.map((interest) => (
-              <Button
-                key={interest.id}
-                type="button"
-                colorScheme="pink"
-                // onClick={() => handleInterestToggle(interest.id)}
-                // isSelected={selectedInterests.includes(interest.id)}
-                className={styles.option}
-              >
-                {interest.label}
-              </Button>
-            ))}
-          </div>
+      <form id="preferences-form" onSubmit={handleSubmit} className={styles.form}>
+        {/* HealthCare */}
+        <CategorySection label="HealthCare*">
+          <SelectionGroup
+            options={toOptions(HEALTH_CARE_PREFERENCES)}
+            selectedValue={healthCareInterests}
+            onSelect={handleHealthCareSelect}
+            layout="horizontal"
+            variant="selection"
+            colorScheme="pink"
+            className={styles.selectionGroup}
+          />
         </CategorySection>
+
+        {/* 여성 의학 관심 분야 - GYNECOLOGY_QNA 선택 시 표시 */}
+        {gynecology.visible && (
+          <div className={`${styles.animatedSection} ${gynecology.exiting ? styles.exiting : ''}`}>
+            <CategorySection label="여성 의학의 어떤 분야에 관심이 있으신가요?">
+              <SelectionGroup
+                options={toOptions(GYNECOLOGY_PREFERENCES)}
+                selectedValue={gynecologyInterests}
+                onSelect={(key) =>
+                  setPreferences({ gynecologyInterests: toggle(gynecologyInterests, key) })
+                }
+                layout="horizontal"
+                variant="selection"
+                colorScheme="pink"
+                className={styles.selectionGroup}
+              />
+            </CategorySection>
+          </div>
+        )}
+
+        {/* 여성 병원 방문 여부 - FIND_HOSPITAL 선택 시 표시 */}
+        {hospital.visible && (
+          <div className={`${styles.animatedSection} ${hospital.exiting ? styles.exiting : ''}`}>
+            <CategorySection label="여성병원을 방문해보신 적이 있으신가요?">
+              <SelectionGroup
+                options={HOSPITAL_VISIT_OPTIONS}
+                selectedValue={hasVisited === null ? '' : String(hasVisited)}
+                onSelect={(key) => setPreferences({ hasVisited: key === 'true' })}
+                layout="horizontal"
+                variant="selection"
+                colorScheme="pink"
+                className={styles.selectionGroup}
+              />
+            </CategorySection>
+
+            <CategorySection label="여성병원을 선택할 때 어떤 것이 중요한가요?">
+              <SelectionGroup
+                options={toOptions(HOSPITAL_PRIORITIES)}
+                selectedValue={hospitalPriorities}
+                onSelect={(key) =>
+                  setPreferences({ hospitalPriorities: toggle(hospitalPriorities, key) })
+                }
+                layout="horizontal"
+                variant="selection"
+                colorScheme="pink"
+                className={styles.selectionGroup}
+              />
+            </CategorySection>
+          </div>
+        )}
+
+        {/* Community */}
+        <CategorySection label="Community*">
+          <SelectionGroup
+            options={toOptions(COMMUNITY_PREFERENCES)}
+            selectedValue={communityInterests}
+            onSelect={(key) =>
+              setPreferences({ communityInterests: toggle(communityInterests, key) })
+            }
+            layout="horizontal"
+            variant="selection"
+            colorScheme="pink"
+            className={styles.selectionGroup}
+          />
+        </CategorySection>
+
+        {/* Commerce */}
+        <CategorySection label="Commerce*">
+          <SelectionGroup
+            options={toOptions(COMMERCE_PREFERENCES)}
+            selectedValue={commerceInterests}
+            onSelect={handleCommerceSelect}
+            layout="horizontal"
+            variant="selection"
+            colorScheme="pink"
+            className={styles.selectionGroup}
+          />
+        </CategorySection>
+
+        {/* 여성 용품 관심사 - PRODUCT_SEARCH 선택 시 표시 */}
+        {product.visible && (
+          <div className={`${styles.animatedSection} ${product.exiting ? styles.exiting : ''}`}>
+            <CategorySection label="어떤 여성용품을 주로 사용하시나요?">
+              <SelectionGroup
+                options={toOptions(FEMININE_CARE_PREFERENCES)}
+                selectedValue={productCategories}
+                onSelect={(key) =>
+                  setPreferences({ productCategories: toggle(productCategories, key) })
+                }
+                layout="horizontal"
+                variant="selection"
+                colorScheme="pink"
+                className={styles.selectionGroup}
+              />
+            </CategorySection>
+          </div>
+        )}
       </form>
+
+      <Button
+        form="preferences-form"
+        type="submit"
+        colorScheme="pink"
+        isLoading={isSubmitting}
+        disabled={isSubmitting}
+        className={styles.submitSticky}
+        style={{ backgroundColor: submitBgColor, transition: 'background-color 0.4s ease' }}
+      >
+        시작하기
+      </Button>
     </section>
   );
 }
 
-export default PreferencesPage;
+export default withAuth(PreferencesPage);

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useState } from 'react';
 import { Home, RotateCcw } from 'lucide-react';
 
+import { ROUTES } from '@repo/shared/constants';
 import { logger } from '@repo/shared/utils';
-import { ROUTES } from '@web/lib/constants';
 
 import clsx from 'clsx';
 import styles from './error.module.scss';

--- a/apps/web/src/components/ui/select/select.tsx
+++ b/apps/web/src/components/ui/select/select.tsx
@@ -75,6 +75,10 @@ export const Select = ({
               setSelectedMonth('');
               setSelectedDay('');
             }}
+            aria-label="출생 연도"
+            aria-required="true"
+            aria-invalid={!!error}
+            aria-describedby={error ? 'birthdate-error' : undefined}
             className={clsx({ [styles.placeholder]: !selectedYear })}
           >
             <option value="" disabled>
@@ -98,6 +102,9 @@ export const Select = ({
               setSelectedDay('');
             }}
             disabled={!selectedYear}
+            aria-label="출생 월"
+            aria-required="true"
+            aria-invalid={!!error}
             className={clsx({ [styles.placeholder]: !selectedMonth })}
           >
             <option value="" disabled>
@@ -118,6 +125,9 @@ export const Select = ({
             value={selectedDay}
             onChange={(e) => setSelectedDay(e.target.value)}
             disabled={!selectedYear || !selectedMonth}
+            aria-label="출생 일"
+            aria-required="true"
+            aria-invalid={!!error}
             className={clsx({ [styles.placeholder]: !selectedDay })}
           >
             <option value="" disabled>
@@ -132,7 +142,11 @@ export const Select = ({
           <ArrowDropDownIcon className={styles.chevronIcon} />
         </section>
       </section>
-      {error && <p className={styles.error}>{error}</p>}
+      {error && (
+        <p id="birthdate-error" role="alert" className={styles.error}>
+          {error}
+        </p>
+      )}
     </div>
   );
 };

--- a/apps/web/src/features/auth/actions/auth.actions.ts
+++ b/apps/web/src/features/auth/actions/auth.actions.ts
@@ -4,13 +4,17 @@ import { AxiosError } from 'axios';
 
 import type { AuthSessionResponse } from '@repo/shared/features/auth';
 import { appleLoginAPI, googleLoginAPI, logoutAPI } from '@repo/shared/features/auth/api/auth.api';
-import { ErrorCode, type ApiResponse } from '@repo/shared/types';
-import { handleError, logger } from '@repo/shared/utils';
-import {
-  createErrorResponse,
-  createErrorResponseFromUnknown,
-  createSuccessResponse,
-} from '@web/lib/utils/server-action';
+import { ErrorCode } from '@repo/shared/types';
+
+interface ActionResponse<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: {
+    code: string;
+    message: string;
+    details?: string;
+  };
+}
 
 /**
  * Exchange OAuth credential for tokens (Server Action)

--- a/apps/web/src/features/auth/actions/auth.actions.ts
+++ b/apps/web/src/features/auth/actions/auth.actions.ts
@@ -1,5 +1,7 @@
 'use server';
 
+import { AxiosError } from 'axios';
+
 import type { AuthSessionResponse } from '@repo/shared/features/auth';
 import { appleLoginAPI, googleLoginAPI, logoutAPI } from '@repo/shared/features/auth/api/auth.api';
 import { ErrorCode, type ApiResponse } from '@repo/shared/types';

--- a/apps/web/src/features/auth/actions/auth.actions.ts
+++ b/apps/web/src/features/auth/actions/auth.actions.ts
@@ -2,17 +2,13 @@
 
 import type { AuthSessionResponse } from '@repo/shared/features/auth';
 import { appleLoginAPI, googleLoginAPI, logoutAPI } from '@repo/shared/features/auth/api/auth.api';
-import { ErrorCode } from '@repo/shared/types';
-
-interface ActionResponse<T = unknown> {
-  success: boolean;
-  data?: T;
-  error?: {
-    code: string;
-    message: string;
-    details?: string;
-  };
-}
+import { ErrorCode, type ApiResponse } from '@repo/shared/types';
+import { handleError, logger } from '@repo/shared/utils';
+import {
+  createErrorResponse,
+  createErrorResponseFromUnknown,
+  createSuccessResponse,
+} from '@web/lib/utils/server-action';
 
 /**
  * Exchange OAuth credential for tokens (Server Action)

--- a/apps/web/src/features/auth/actions/auth.actions.ts
+++ b/apps/web/src/features/auth/actions/auth.actions.ts
@@ -1,7 +1,5 @@
 'use server';
 
-import { AxiosError } from 'axios';
-
 import type { AuthSessionResponse } from '@repo/shared/features/auth';
 import { appleLoginAPI, googleLoginAPI, logoutAPI } from '@repo/shared/features/auth/api/auth.api';
 import { ErrorCode } from '@repo/shared/types';

--- a/apps/web/src/features/onboarding/actions/__tests__/onboarding.actions.test.ts
+++ b/apps/web/src/features/onboarding/actions/__tests__/onboarding.actions.test.ts
@@ -1,0 +1,142 @@
+import { ErrorCode } from '@repo/shared/types';
+
+import { registerPreferencesAPI } from '../../api/onboarding.api';
+import {
+  COMMERCE_PREFERENCES,
+  COMMUNITY_PREFERENCES,
+  FEMININE_CARE_PREFERENCES,
+  GYNECOLOGY_PREFERENCES,
+  HEALTH_CARE_PREFERENCES,
+  HOSPITAL_PRIORITIES,
+} from '../../constants/onboarding.constants';
+import type { PreferencesRequest } from '../../types/onboarding.type';
+import { registerPreferences } from '../onboarding.actions';
+
+// ─── Mocks ────────────────────────────────────────────────────────────
+jest.mock('../../api/onboarding.api', () => ({
+  getRandomNicknameAPI: jest.fn(),
+  registerUserAPI: jest.fn(),
+  registerPreferencesAPI: jest.fn(),
+}));
+
+jest.mock('@repo/shared/utils', () => ({
+  logger: {
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  },
+  handleError: jest.fn(),
+  transformError: jest.fn((e: unknown) => e),
+}));
+
+const mockedRegisterPreferencesAPI = registerPreferencesAPI as jest.MockedFunction<
+  typeof registerPreferencesAPI
+>;
+
+// ─── Test Data ────────────────────────────────────────────────────────
+function validPreferencesRequest(): PreferencesRequest {
+  return {
+    healthCareInterests: [HEALTH_CARE_PREFERENCES[0].id],
+    gynecologyInterests: [GYNECOLOGY_PREFERENCES[0].id],
+    hasVisited: false,
+    hospitalPriorities: [HOSPITAL_PRIORITIES[0].id],
+    communityInterests: [COMMUNITY_PREFERENCES[0].id],
+    commerceInterests: [COMMERCE_PREFERENCES[0].id],
+    productCategories: [FEMININE_CARE_PREFERENCES[0].id],
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────
+describe('registerPreferences', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns success response when data is valid and API succeeds', async () => {
+    mockedRegisterPreferencesAPI.mockResolvedValue('OK');
+
+    const result = await registerPreferences(validPreferencesRequest());
+
+    expect(result).toEqual({
+      success: true,
+      data: 'OK',
+    });
+    expect(mockedRegisterPreferencesAPI).toHaveBeenCalledWith(validPreferencesRequest());
+  });
+
+  it('returns validation error when data has invalid IDs', async () => {
+    const invalidData: PreferencesRequest = {
+      ...validPreferencesRequest(),
+      healthCareInterests: ['INVALID_ID'],
+    };
+
+    const result = await registerPreferences(invalidData);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe(ErrorCode.VALIDATION_ERROR);
+    expect(mockedRegisterPreferencesAPI).not.toHaveBeenCalled();
+  });
+
+  it('returns validation error when hasVisited is not boolean', async () => {
+    const invalidData = {
+      ...validPreferencesRequest(),
+      hasVisited: 'yes' as unknown as boolean,
+    };
+
+    const result = await registerPreferences(invalidData as PreferencesRequest);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe(ErrorCode.VALIDATION_ERROR);
+    expect(mockedRegisterPreferencesAPI).not.toHaveBeenCalled();
+  });
+
+  it('returns error response when API throws', async () => {
+    mockedRegisterPreferencesAPI.mockRejectedValue(new Error('Network Error'));
+
+    const result = await registerPreferences(validPreferencesRequest());
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe(ErrorCode.UNKNOWN_ERROR);
+    expect(result.error?.message).toBe('Network Error');
+  });
+
+  it('returns error response for non-Error thrown values', async () => {
+    mockedRegisterPreferencesAPI.mockRejectedValue({ status: 500 });
+
+    const result = await registerPreferences(validPreferencesRequest());
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe(ErrorCode.UNKNOWN_ERROR);
+  });
+
+  it('passes parsed (validated) data to the API, not raw input', async () => {
+    mockedRegisterPreferencesAPI.mockResolvedValue('OK');
+
+    await registerPreferences(validPreferencesRequest());
+
+    // The API should have been called with the data - ensuring schema parsing happened
+    expect(mockedRegisterPreferencesAPI).toHaveBeenCalledTimes(1);
+    const calledWith = mockedRegisterPreferencesAPI.mock.calls[0][0];
+    expect(calledWith.healthCareInterests).toEqual(validPreferencesRequest().healthCareInterests);
+  });
+
+  it('accepts empty arrays for optional sub-section fields', async () => {
+    // gynecologyInterests, hospitalPriorities, productCategories are conditionally shown
+    // and may legitimately be empty. Required fields must have at least one value.
+    const data: PreferencesRequest = {
+      healthCareInterests: validPreferencesRequest().healthCareInterests,
+      gynecologyInterests: [],
+      hasVisited: false,
+      hospitalPriorities: [],
+      communityInterests: validPreferencesRequest().communityInterests,
+      commerceInterests: validPreferencesRequest().commerceInterests,
+      productCategories: [],
+    };
+    mockedRegisterPreferencesAPI.mockResolvedValue('OK');
+
+    const result = await registerPreferences(data);
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/web/src/features/onboarding/actions/onboarding.actions.ts
+++ b/apps/web/src/features/onboarding/actions/onboarding.actions.ts
@@ -1,14 +1,19 @@
 'use server';
 
-import { ApiResponse } from '@repo/shared/types';
+import { ApiResponse, ErrorCode } from '@repo/shared/types';
 import {
+  createErrorResponse,
   createErrorResponseFromUnknown,
   createSuccessResponse,
 } from '@web/lib/utils/server-action';
 
-import { getRandomNicknameAPI, registerUserAPI } from '../api/onboarding.api';
-import { ageSchema, nicknameSchema } from '../schemas/validation.schemas';
-import { SubmitRequest, SubmitResponse } from '../types/onboarding.type';
+import {
+  getRandomNicknameAPI,
+  registerPreferencesAPI,
+  registerUserAPI,
+} from '../api/onboarding.api';
+import { ageSchema, nicknameSchema, preferencesSchema } from '../schemas/validation.schemas';
+import { PreferencesRequest, SubmitRequest, SubmitResponse } from '../types/onboarding.type';
 import { validateFieldsForServer } from '../utils/validation.utils';
 
 export async function getRandomNickname(): Promise<ApiResponse<{ randomNickname: string }>> {
@@ -25,6 +30,20 @@ export async function getRandomNickname(): Promise<ApiResponse<{ randomNickname:
  * @param data data to register user
  * @returns success or failure and registered user data
  */
+export async function registerPreferences(data: PreferencesRequest): Promise<ApiResponse<string>> {
+  try {
+    const parsed = preferencesSchema.safeParse(data);
+    if (!parsed.success) {
+      return createErrorResponse(ErrorCode.VALIDATION_ERROR, '잘못된 요청입니다.');
+    }
+
+    const result = await registerPreferencesAPI(parsed.data);
+    return createSuccessResponse(result);
+  } catch (error) {
+    return createErrorResponseFromUnknown(error);
+  }
+}
+
 export async function registerUser(data: SubmitRequest): Promise<ApiResponse<SubmitResponse>> {
   try {
     const requiredFieldsError = validateFieldsForServer<SubmitResponse>([

--- a/apps/web/src/features/onboarding/api/onboarding.api.ts
+++ b/apps/web/src/features/onboarding/api/onboarding.api.ts
@@ -1,5 +1,3 @@
-import axios, { AxiosError } from 'axios';
-
 import { ApiResponse, AppError, ErrorCode } from '@repo/shared/types';
 import { transformError } from '@repo/shared/utils';
 import { api } from '@web/api/api';

--- a/apps/web/src/features/onboarding/api/onboarding.api.ts
+++ b/apps/web/src/features/onboarding/api/onboarding.api.ts
@@ -1,3 +1,5 @@
+import axios, { AxiosError } from 'axios';
+
 import { ApiResponse, AppError, ErrorCode } from '@repo/shared/types';
 import { transformError } from '@repo/shared/utils';
 import { api } from '@web/api/api';

--- a/apps/web/src/features/onboarding/api/onboarding.api.ts
+++ b/apps/web/src/features/onboarding/api/onboarding.api.ts
@@ -1,8 +1,8 @@
 import { ApiResponse, AppError, ErrorCode } from '@repo/shared/types';
-import { transformError } from '@repo/shared/utils';
+import { logger, transformError } from '@repo/shared/utils';
 import { api } from '@web/api/api';
 
-import { SubmitRequest, SubmitResponse } from '../types/onboarding.type';
+import { PreferencesRequest, SubmitRequest, SubmitResponse } from '../types/onboarding.type';
 
 // random nickname generator
 export async function getRandomNicknameAPI(): Promise<string> {
@@ -17,15 +17,35 @@ export async function getRandomNicknameAPI(): Promise<string> {
   }
 }
 
-// user registration API
+// user registration
 export async function registerUserAPI(formData: SubmitRequest): Promise<SubmitResponse> {
   try {
-    const response = await api.post<SubmitResponse>('/users', formData);
-    if (response.nickname) {
-      return response;
+    const response = await api.post<ApiResponse<SubmitResponse>>('/users', formData);
+    logger.info('[registerUserAPI] response:', response as unknown as Record<string, unknown>);
+    if (response.success && response.data) {
+      return response.data;
     }
     throw new AppError(ErrorCode.UNKNOWN_ERROR, 'Failed to register user');
   } catch (error: unknown) {
+    logger.error('[registerUserAPI] error:', error as unknown as Record<string, unknown>);
+    throw transformError(error);
+  }
+}
+
+// user preferences submission
+export async function registerPreferencesAPI(formData: PreferencesRequest): Promise<string> {
+  try {
+    const response = await api.post<ApiResponse<string>>('/users/preference', formData);
+    logger.info(
+      '[registerPreferencesAPI] response:',
+      response as unknown as Record<string, unknown>,
+    );
+    if (response.success) {
+      return response.data ?? '';
+    }
+    throw new AppError(ErrorCode.UNKNOWN_ERROR, 'Failed to register preferences');
+  } catch (error: unknown) {
+    logger.error('[registerPreferencesAPI] error:', error as unknown as Record<string, unknown>);
     throw transformError(error);
   }
 }

--- a/apps/web/src/features/onboarding/constants/onboarding.constants.ts
+++ b/apps/web/src/features/onboarding/constants/onboarding.constants.ts
@@ -1,14 +1,16 @@
-export const MOCK_RANDOM_NICKNAME = 'luna_user_1234';
+export const ERROR_MESSAGES = {
+  GENERIC: '오류가 발생했습니다. 다시 시도해주세요.',
+} as const;
 
-export const HEALTH_CARE_INTERESTS = [
+export const HEALTH_CARE_PREFERENCES = [
   { id: 'GYNECOLOGY_QNA', label: '여성 의학 궁금증 해결' },
   { id: 'FIND_HOSPITAL', label: '나에게 맞는 여성병원 찾기' },
   { id: 'PRODUCT_REVIEW', label: '여성용품 후기 탐색' },
   { id: 'HEALTH_REPORT', label: '맞춤형 건강 보고서' },
 ];
 
-// GYNECOLOGY_QNA 하위 항목
-export const GYNECOLOGY_INTERESTS = [
+// 여성의학 궁금증 해결
+export const GYNECOLOGY_PREFERENCES = [
   { id: 'MENSTRUAL_PAIN', label: '월경통' },
   { id: 'IRREGULAR_PERIOD', label: '생리불순' },
   { id: 'PMS', label: 'PMS' },
@@ -26,36 +28,36 @@ export const GYNECOLOGY_INTERESTS = [
 
 // 여성병원 선택 시 고려사항
 export const HOSPITAL_PRIORITIES = [
-  { id: 'FEMALE_DOCTOR', label: '여의사 진료 여부' },
-  { id: 'SHORT_DISTANCE', label: '병원과의 거리' },
-  { id: 'KINDNESS', label: '병원 친절도' },
-  { id: 'DETAILED_EXPLANATION', label: '의사의 자세한 설명 여부' },
+  { id: 'FEMALE_DOCTOR', label: '여의사 진료' },
+  { id: 'SHORT_DISTANCE', label: '가까운 거리' },
+  { id: 'KINDNESS', label: '친절도' },
+  { id: 'DETAILED_EXPLANATION', label: '자세한 설명' },
   { id: 'DOCTOR_EXPERTISE', label: '의사의 전문성과 평판' },
-  { id: 'LATEST_EQUIPMENT', label: '최신 의료장비 보유 여부' },
+  { id: 'LATEST_EQUIPMENT', label: '최신 의료장비' },
   { id: 'NO_OVERTREATMENT', label: '과잉진료 여부' },
-  { id: 'PARKING_FACILITIES', label: '주차장 및 부대시설 여부' },
+  { id: 'PARKING_FACILITIES', label: '주차장 및 부대시설' },
   { id: 'COMFORTABLE_WAITING', label: '대기 공간의 편안함' },
   { id: 'WAITING_TIME', label: '대기시간' },
-  { id: 'HONEST_REVIEWS', label: '실 방문자의 솔직한 후기 존재 여부' },
+  { id: 'HONEST_REVIEWS', label: '실 방문자의 솔직한 후기' },
   { id: 'SEARCH_RATING', label: '검색 시 평점' },
-  { id: 'SNS_REVIEWS', label: 'SNS 후기 존재 여부' },
-  { id: 'DISEASE_SPECIALTY', label: '질환별 전문성 여부' },
-  { id: 'COST_TRANSPARENCY', label: '비용 투명성 여부' },
+  { id: 'SNS_REVIEWS', label: 'SNS 후기' },
+  { id: 'DISEASE_SPECIALTY', label: '질환별 전문성' },
+  { id: 'COST_TRANSPARENCY', label: '비용 투명성' },
   { id: 'NIGHT_CARE', label: '야간 진료 여부' },
 ];
 
-export const COMMUNITY_INTERESTS = [
+export const COMMUNITY_PREFERENCES = [
   { id: 'COMMUNITY', label: '커뮤니티' },
   { id: 'HONEST_REVIEWS', label: '솔직한 리뷰 보기' },
   { id: 'EXPERT_COLUMN', label: '전문가 칼럼' },
 ];
 
-export const COMMERCE_INTERESTS = [
+export const COMMERCE_PREFERENCES = [
   { id: 'PRODUCT_SEARCH', label: '여성용품 탐색' },
   { id: 'PRICE_COMPARISON', label: '최저가 비교' },
 ];
 
-export const FEMININE_CARE_INTERESTS = [
+export const FEMININE_CARE_PREFERENCES = [
   { id: 'TAMPON', label: '탐폰' },
   { id: 'SANITARY_PAD', label: '생리대 (패드)' },
   { id: 'MENSTRUAL_DISC', label: '생리 디스크' },

--- a/apps/web/src/features/onboarding/hooks/__tests__/use-animated-section.test.ts
+++ b/apps/web/src/features/onboarding/hooks/__tests__/use-animated-section.test.ts
@@ -1,0 +1,139 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useAnimatedSection } from '../use-animated-section';
+
+// ─── Tests ────────────────────────────────────────────────────────────
+describe('useAnimatedSection', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('starts with visible=false and exiting=false when show=false', () => {
+    const { result } = renderHook(() => useAnimatedSection(false));
+
+    expect(result.current.visible).toBe(false);
+    expect(result.current.exiting).toBe(false);
+  });
+
+  it('starts with visible=true and exiting=false when show=true (rehydration)', () => {
+    // On initial render with show=true, visible is initialized to true.
+    // prev.current also starts as true, so neither transition branch fires.
+    const { result } = renderHook(() => useAnimatedSection(true));
+
+    expect(result.current.visible).toBe(true);
+    expect(result.current.exiting).toBe(false);
+  });
+
+  it('sets visible=true when show transitions from false to true', () => {
+    const { result, rerender } = renderHook(({ show }) => useAnimatedSection(show), {
+      initialProps: { show: false },
+    });
+
+    rerender({ show: true });
+
+    expect(result.current.visible).toBe(true);
+    expect(result.current.exiting).toBe(false);
+  });
+
+  it('sets exiting=true immediately when show transitions from true to false', () => {
+    const { result, rerender } = renderHook(({ show }) => useAnimatedSection(show), {
+      initialProps: { show: false },
+    });
+
+    // First transition: false -> true
+    rerender({ show: true });
+    expect(result.current.visible).toBe(true);
+
+    // Second transition: true -> false
+    rerender({ show: false });
+    expect(result.current.exiting).toBe(true);
+    expect(result.current.visible).toBe(true); // Still visible during exit animation
+  });
+
+  it('sets visible=false after exitDuration when show transitions to false', () => {
+    const { result, rerender } = renderHook(({ show }) => useAnimatedSection(show, 300), {
+      initialProps: { show: false },
+    });
+
+    rerender({ show: true });
+    rerender({ show: false });
+
+    // Before timeout
+    expect(result.current.visible).toBe(true);
+
+    // After timeout
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(result.current.visible).toBe(false);
+    expect(result.current.exiting).toBe(true);
+  });
+
+  it('uses default exitDuration of 200ms', () => {
+    const { result, rerender } = renderHook(({ show }) => useAnimatedSection(show), {
+      initialProps: { show: false },
+    });
+
+    rerender({ show: true });
+    rerender({ show: false });
+
+    // Before default timeout
+    act(() => {
+      jest.advanceTimersByTime(199);
+    });
+    expect(result.current.visible).toBe(true);
+
+    // At default timeout
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current.visible).toBe(false);
+  });
+
+  it('clears timeout on unmount to prevent memory leaks', () => {
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+
+    const { rerender, unmount } = renderHook(({ show }) => useAnimatedSection(show), {
+      initialProps: { show: false },
+    });
+
+    rerender({ show: true });
+    rerender({ show: false });
+
+    unmount();
+
+    // clearTimeout should have been called during cleanup
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+
+  it('cancels pending exit when show transitions back to true', () => {
+    const { result, rerender } = renderHook(({ show }) => useAnimatedSection(show), {
+      initialProps: { show: false },
+    });
+
+    // false -> true
+    rerender({ show: true });
+    expect(result.current.visible).toBe(true);
+
+    // true -> false (starts exit)
+    rerender({ show: false });
+    expect(result.current.exiting).toBe(true);
+
+    // false -> true again (cancels exit)
+    rerender({ show: true });
+    expect(result.current.visible).toBe(true);
+    expect(result.current.exiting).toBe(false);
+
+    // Advance past exit duration - should still be visible
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(result.current.visible).toBe(true);
+  });
+});

--- a/apps/web/src/features/onboarding/hooks/__tests__/use-birthdate-validation.test.ts
+++ b/apps/web/src/features/onboarding/hooks/__tests__/use-birthdate-validation.test.ts
@@ -1,0 +1,157 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { validate } from '../../utils/validation.utils';
+import { useBirthdateValidation } from '../use-birthdate-validation';
+
+// ─── Mocks ────────────────────────────────────────────────────────────
+const mockSetBirthDateSelection = jest.fn();
+const mockSetAge = jest.fn();
+let mockBirthDateSelection = { year: '', month: '', day: '' };
+
+jest.mock('../../stores/use-onboarding-store', () => ({
+  useOnboardingStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      birthDateSelection: mockBirthDateSelection,
+      setBirthDateSelection: mockSetBirthDateSelection,
+      setAge: mockSetAge,
+    }),
+}));
+
+jest.mock('../../schemas/validation.schemas', () => ({
+  birthdateSelectionSchema: {
+    // Real zod schema replaced with a simple stub
+    // Valid when all three fields are non-empty and year < current year
+    parse: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/validation.utils', () => ({
+  calculateAge: jest.fn(() => 25),
+  validate: jest.fn(),
+}));
+
+const mockedValidate = validate as jest.MockedFunction<typeof validate>;
+
+// ─── Tests ────────────────────────────────────────────────────────────
+describe('useBirthdateValidation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBirthDateSelection = { year: '', month: '', day: '' };
+  });
+
+  describe('initial state', () => {
+    it('returns empty birthDateSelection from store', () => {
+      const { result } = renderHook(() => useBirthdateValidation());
+
+      expect(result.current.birthDateSelection).toEqual({ year: '', month: '', day: '' });
+    });
+
+    it('isDateComplete is false when fields are empty', () => {
+      const { result } = renderHook(() => useBirthdateValidation());
+
+      expect(result.current.isDateComplete).toBe(false);
+    });
+
+    it('isValid is false initially', () => {
+      const { result } = renderHook(() => useBirthdateValidation());
+
+      expect(result.current.isValid).toBe(false);
+    });
+
+    it('error is null initially', () => {
+      const { result } = renderHook(() => useBirthdateValidation());
+
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe('handleDateChange', () => {
+    it('calls setBirthDateSelection with new date', () => {
+      const { result } = renderHook(() => useBirthdateValidation());
+      const newDate = { year: '1999', month: '06', day: '15' };
+
+      act(() => {
+        result.current.handleDateChange(newDate);
+      });
+
+      expect(mockSetBirthDateSelection).toHaveBeenCalledWith(newDate);
+    });
+
+    it('resets validation result on date change', () => {
+      mockedValidate.mockReturnValue({ isValid: true, error: null });
+      const { result } = renderHook(() => useBirthdateValidation());
+
+      act(() => {
+        result.current.validateBirthdate();
+      });
+
+      act(() => {
+        result.current.handleDateChange({ year: '1990', month: '01', day: '01' });
+      });
+
+      expect(result.current.isValid).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe('isDateComplete', () => {
+    it('is true when all fields are set', () => {
+      mockBirthDateSelection = { year: '1999', month: '06', day: '15' };
+
+      const { result } = renderHook(() => useBirthdateValidation());
+
+      expect(result.current.isDateComplete).toBe(true);
+    });
+
+    it('is false when only some fields are set', () => {
+      mockBirthDateSelection = { year: '1999', month: '', day: '' };
+
+      const { result } = renderHook(() => useBirthdateValidation());
+
+      expect(result.current.isDateComplete).toBe(false);
+    });
+  });
+
+  describe('validateBirthdate', () => {
+    it('returns true and calls setAge when validation succeeds', () => {
+      mockBirthDateSelection = { year: '1999', month: '06', day: '15' };
+      mockedValidate.mockReturnValue({ isValid: true, error: null });
+
+      const { result } = renderHook(() => useBirthdateValidation());
+
+      let isValid: boolean;
+      act(() => {
+        isValid = result.current.validateBirthdate();
+      });
+
+      expect(isValid!).toBe(true);
+      expect(mockSetAge).toHaveBeenCalledWith(25);
+    });
+
+    it('returns false and does not call setAge when validation fails', () => {
+      mockedValidate.mockReturnValue({ isValid: false, error: '유효한 생년월일을 선택해주세요.' });
+
+      const { result } = renderHook(() => useBirthdateValidation());
+
+      let isValid: boolean;
+      act(() => {
+        isValid = result.current.validateBirthdate();
+      });
+
+      expect(isValid!).toBe(false);
+      expect(mockSetAge).not.toHaveBeenCalled();
+    });
+
+    it('sets error message on failure', () => {
+      mockedValidate.mockReturnValue({ isValid: false, error: '유효한 생년월일을 선택해주세요.' });
+
+      const { result } = renderHook(() => useBirthdateValidation());
+
+      act(() => {
+        result.current.validateBirthdate();
+      });
+
+      expect(result.current.error).toBe('유효한 생년월일을 선택해주세요.');
+    });
+  });
+});

--- a/apps/web/src/features/onboarding/hooks/__tests__/use-onboarding-navigation.test.ts
+++ b/apps/web/src/features/onboarding/hooks/__tests__/use-onboarding-navigation.test.ts
@@ -1,0 +1,124 @@
+import { renderHook } from '@testing-library/react';
+
+import { toast } from '@web/components/ui/toast';
+
+import { useOnboardingComplete, useOnboardingNavigationGuard } from '../use-onboarding-navigation';
+
+// ─── Mocks ────────────────────────────────────────────────────────────
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: mockReplace,
+  }),
+}));
+
+jest.mock('@repo/shared/constants', () => ({
+  ROUTES: {
+    ONBOARDING_NAME: '/onboarding/name',
+    ONBOARDING_AGE: '/onboarding/age',
+    ONBOARDING_PREFERENCES: '/onboarding/preferences',
+    ROOT: '/',
+  },
+}));
+
+jest.mock('@repo/shared/utils', () => ({
+  logger: {
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+jest.mock('@web/components/ui/toast', () => ({
+  toast: {
+    warning: jest.fn(),
+    error: jest.fn(),
+    success: jest.fn(),
+  },
+}));
+
+const mockedToastWarning = toast.warning as jest.Mock;
+
+// ─── Tests ────────────────────────────────────────────────────────────
+describe('useOnboardingNavigationGuard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('redirects to ONBOARDING_NAME when nickname is required but missing', () => {
+    renderHook(() => useOnboardingNavigationGuard({ requireNickname: true, nickname: '' }));
+
+    expect(mockPush).toHaveBeenCalledWith('/onboarding/name');
+    expect(mockedToastWarning).toHaveBeenCalledWith('이전 단계가 완료되지 않았어요!');
+  });
+
+  it('redirects to ONBOARDING_AGE when age is required but missing', () => {
+    renderHook(() =>
+      useOnboardingNavigationGuard({
+        requireNickname: true,
+        requireAge: true,
+        nickname: 'luna',
+        age: 0,
+      }),
+    );
+
+    expect(mockPush).toHaveBeenCalledWith('/onboarding/age');
+  });
+
+  it('does not redirect when all required fields are present', () => {
+    renderHook(() =>
+      useOnboardingNavigationGuard({
+        requireNickname: true,
+        requireAge: true,
+        nickname: 'luna',
+        age: 25,
+      }),
+    );
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('does not redirect when no requirements are set', () => {
+    renderHook(() => useOnboardingNavigationGuard({}));
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('checks nickname requirement only when requireNickname is true', () => {
+    renderHook(() => useOnboardingNavigationGuard({ requireNickname: false, nickname: '' }));
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('checks age requirement only when requireAge is true', () => {
+    renderHook(() =>
+      useOnboardingNavigationGuard({
+        requireNickname: true,
+        requireAge: false,
+        nickname: 'luna',
+        age: 0,
+      }),
+    );
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});
+
+// ─── useOnboardingComplete ────────────────────────────────────────────
+describe('useOnboardingComplete', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('navigates to ROOT when completeOnboarding is called', () => {
+    const { result } = renderHook(() => useOnboardingComplete());
+
+    result.current.completeOnboarding();
+
+    expect(mockPush).toHaveBeenCalledWith('/');
+  });
+});

--- a/apps/web/src/features/onboarding/hooks/__tests__/use-onboarding-validation.test.ts
+++ b/apps/web/src/features/onboarding/hooks/__tests__/use-onboarding-validation.test.ts
@@ -1,0 +1,200 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { ErrorCode } from '@repo/shared/types';
+import { toast } from '@web/components/ui/toast';
+
+import { getRandomNickname } from '../../actions/onboarding.actions';
+import { validate } from '../../utils/validation.utils';
+import { useNicknameValidation } from '../use-onboarding-validation';
+
+// ─── Mocks ────────────────────────────────────────────────────────────
+const mockSetNickname = jest.fn();
+let mockNickname = '';
+
+jest.mock('../../stores/use-onboarding-store', () => ({
+  useOnboardingStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      nickname: mockNickname,
+      setNickname: mockSetNickname,
+    }),
+}));
+
+jest.mock('../../actions/onboarding.actions', () => ({
+  getRandomNickname: jest.fn(),
+}));
+
+jest.mock('../../schemas/validation.schemas', () => ({
+  nicknameSchema: {},
+}));
+
+jest.mock('../../utils/validation.utils', () => ({
+  validate: jest.fn(),
+}));
+
+jest.mock('@web/components/ui/toast', () => ({
+  toast: {
+    error: jest.fn(),
+    success: jest.fn(),
+    warning: jest.fn(),
+  },
+}));
+
+const mockedGetRandomNickname = getRandomNickname as jest.MockedFunction<typeof getRandomNickname>;
+const mockedValidate = validate as jest.MockedFunction<typeof validate>;
+const mockedToastError = toast.error as jest.Mock;
+
+// ─── Tests ────────────────────────────────────────────────────────────
+describe('useNicknameValidation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNickname = '';
+    mockedValidate.mockReturnValue({ isValid: true, error: null });
+  });
+
+  describe('initial state', () => {
+    it('isValid is true initially', () => {
+      const { result } = renderHook(() => useNicknameValidation());
+      expect(result.current.isValid).toBe(true);
+    });
+
+    it('error is null initially', () => {
+      const { result } = renderHook(() => useNicknameValidation());
+      expect(result.current.error).toBeNull();
+    });
+
+    it('isLoading is false initially', () => {
+      const { result } = renderHook(() => useNicknameValidation());
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe('handleNicknameChange', () => {
+    it('calls setNickname with new value', () => {
+      const { result } = renderHook(() => useNicknameValidation());
+
+      act(() => {
+        result.current.handleNicknameChange('luna');
+      });
+
+      expect(mockSetNickname).toHaveBeenCalledWith('luna');
+    });
+
+    it('updates isValid based on validation result', () => {
+      mockedValidate.mockReturnValue({
+        isValid: false,
+        error: '닉네임은 최소 2자 이상이어야 합니다.',
+      });
+
+      const { result } = renderHook(() => useNicknameValidation());
+
+      act(() => {
+        result.current.handleNicknameChange('a');
+      });
+
+      expect(result.current.isValid).toBe(false);
+      expect(result.current.error).toBe('닉네임은 최소 2자 이상이어야 합니다.');
+    });
+  });
+
+  describe('validateNickname', () => {
+    it('returns true when validation passes', () => {
+      mockedValidate.mockReturnValue({ isValid: true, error: null });
+
+      const { result } = renderHook(() => useNicknameValidation());
+
+      let isValid: boolean;
+      act(() => {
+        isValid = result.current.validateNickname();
+      });
+
+      expect(isValid!).toBe(true);
+    });
+
+    it('returns false and sets error when validation fails', () => {
+      mockedValidate.mockReturnValue({ isValid: false, error: '닉네임을 입력해주세요.' });
+
+      const { result } = renderHook(() => useNicknameValidation());
+
+      let isValid: boolean;
+      act(() => {
+        isValid = result.current.validateNickname();
+      });
+
+      expect(isValid!).toBe(false);
+      expect(result.current.error).toBe('닉네임을 입력해주세요.');
+    });
+  });
+
+  describe('fetchRecommendedNickname', () => {
+    it('sets nickname from API response on success', async () => {
+      mockedGetRandomNickname.mockResolvedValue({
+        success: true,
+        data: { randomNickname: 'LunaUser' },
+      });
+
+      const { result } = renderHook(() => useNicknameValidation());
+
+      await act(async () => {
+        await result.current.fetchRecommendedNickname();
+      });
+
+      expect(mockSetNickname).toHaveBeenCalledWith('LunaUser');
+    });
+
+    it('sets isLoading=true during fetch and false after', async () => {
+      let resolvePromise!: (
+        v: ReturnType<typeof mockedGetRandomNickname> extends Promise<infer R> ? R : never,
+      ) => void;
+      mockedGetRandomNickname.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolvePromise = resolve as typeof resolvePromise;
+          }),
+      );
+
+      const { result } = renderHook(() => useNicknameValidation());
+
+      act(() => {
+        result.current.fetchRecommendedNickname();
+      });
+
+      expect(result.current.isLoading).toBe(true);
+
+      await act(async () => {
+        resolvePromise({ success: true, data: { randomNickname: 'LunaUser' } });
+      });
+
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('shows toast error when API throws', async () => {
+      mockedGetRandomNickname.mockRejectedValue(new Error('Network failure'));
+
+      const { result } = renderHook(() => useNicknameValidation());
+
+      await act(async () => {
+        await result.current.fetchRecommendedNickname();
+      });
+
+      expect(mockedToastError).toHaveBeenCalledWith(
+        '닉네임 추천을 불러오지 못했습니다. 다시 시도해주세요.',
+      );
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('does not set nickname when API returns success=false', async () => {
+      mockedGetRandomNickname.mockResolvedValue({
+        success: false,
+        error: { code: ErrorCode.UNKNOWN_ERROR, message: '오류' },
+      });
+
+      const { result } = renderHook(() => useNicknameValidation());
+
+      await act(async () => {
+        await result.current.fetchRecommendedNickname();
+      });
+
+      expect(mockSetNickname).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/features/onboarding/hooks/use-animated-section.ts
+++ b/apps/web/src/features/onboarding/hooks/use-animated-section.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Hook that manages enter/exit animation state for a conditionally-visible section.
+ *
+ * When `show` transitions from false to true: sets visible=true, exiting=false.
+ * When `show` transitions from true to false: sets exiting=true, then after
+ * `exitDuration` ms sets visible=false.
+ */
+export function useAnimatedSection(show: boolean, exitDuration = 200) {
+  const [visible, setVisible] = useState(show);
+  const [exiting, setExiting] = useState(false);
+  const prev = useRef(show);
+
+  useEffect(() => {
+    let t: ReturnType<typeof setTimeout> | undefined;
+    if (show && !prev.current) {
+      setExiting(false);
+      setVisible(true);
+    } else if (!show && prev.current) {
+      setExiting(true);
+      t = setTimeout(() => setVisible(false), exitDuration);
+    }
+    prev.current = show;
+    return () => clearTimeout(t);
+  }, [show, exitDuration]);
+
+  return { visible, exiting };
+}

--- a/apps/web/src/features/onboarding/hooks/use-onboarding-navigation.ts
+++ b/apps/web/src/features/onboarding/hooks/use-onboarding-navigation.ts
@@ -23,14 +23,14 @@ export function useOnboardingNavigationGuard({
   useEffect(() => {
     if (requireNickname && !nickname) {
       logger.warn('[Navigation Guard] Nickname required');
-      toast.warning('Please complete the previous step first.');
+      toast.warning('이전 단계가 완료되지 않았어요!');
       router.push(ROUTES.ONBOARDING_NAME);
       return;
     }
 
     if (requireAge && (!age || age === 0)) {
       logger.warn('[Navigation Guard] Age required');
-      toast.warning('Please complete your profile step by step.');
+      toast.warning('이전 단계가 완료되지 않았어요!');
       router.push(ROUTES.ONBOARDING_AGE);
       return;
     }

--- a/apps/web/src/features/onboarding/hooks/use-onboarding-validation.ts
+++ b/apps/web/src/features/onboarding/hooks/use-onboarding-validation.ts
@@ -1,4 +1,6 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
+
+import { toast } from '@web/components/ui/toast';
 
 import { getRandomNickname } from '../actions/onboarding.actions';
 import { nicknameSchema } from '../schemas/validation.schemas';
@@ -15,6 +17,21 @@ export function useNicknameValidation() {
   const nickname = useOnboardingStore((s) => s.nickname);
   const setNickname = useOnboardingStore((s) => s.setNickname);
 
+  const handleNicknameChange = useCallback(
+    (value: string) => {
+      setNickname(value);
+      const { isValid, error } = validate(value, nicknameSchema);
+      setResult((prev) => ({ ...prev, isValid, error }));
+    },
+    [setNickname],
+  );
+
+  const validateNickname = useCallback((): boolean => {
+    const { isValid, error } = validate(nickname, nicknameSchema);
+    setResult((prev) => ({ ...prev, isValid, error }));
+    return isValid;
+  }, [nickname]);
+
   const fetchRecommendedNickname = async () => {
     setResult((prev) => ({ ...prev, isLoading: true }));
 
@@ -26,23 +43,10 @@ export function useNicknameValidation() {
         setNickname(randomNickname);
       }
     } catch {
-      // silently fail — user can still type their own nickname
+      toast.error('닉네임 추천을 불러오지 못했습니다. 다시 시도해주세요.');
     } finally {
       setResult((prev) => ({ ...prev, isLoading: false }));
     }
-  };
-
-  const handleNicknameChange = (value: string) => {
-    setNickname(value);
-    const { isValid, error } = validate(value, nicknameSchema);
-    setResult((prev) => ({ ...prev, isValid, error }));
-  };
-
-  // validate nickname schema only (no server duplicate check)
-  const validateNickname = (): boolean => {
-    const validationResult = validate(nickname, nicknameSchema);
-    setResult({ ...validationResult, isLoading: false });
-    return validationResult.isValid;
   };
 
   return {

--- a/apps/web/src/features/onboarding/hooks/use-onboarding-validation.ts
+++ b/apps/web/src/features/onboarding/hooks/use-onboarding-validation.ts
@@ -47,9 +47,9 @@ export function useNicknameValidation() {
 
   return {
     nickname,
+    fetchRecommendedNickname,
     handleNicknameChange,
     validateNickname,
-    fetchRecommendedNickname,
     isValid: result.isValid,
     error: result.error,
     isLoading: result.isLoading,

--- a/apps/web/src/features/onboarding/hooks/use-onboarding-validation.ts
+++ b/apps/web/src/features/onboarding/hooks/use-onboarding-validation.ts
@@ -47,9 +47,9 @@ export function useNicknameValidation() {
 
   return {
     nickname,
-    fetchRecommendedNickname,
     handleNicknameChange,
     validateNickname,
+    fetchRecommendedNickname,
     isValid: result.isValid,
     error: result.error,
     isLoading: result.isLoading,

--- a/apps/web/src/features/onboarding/index.ts
+++ b/apps/web/src/features/onboarding/index.ts
@@ -1,4 +1,5 @@
 // Hooks
+export { useAnimatedSection } from './hooks/use-animated-section';
 export { useBirthdateValidation } from './hooks/use-birthdate-validation';
 export {
   useOnboardingComplete,
@@ -14,14 +15,18 @@ export { Title } from './components/title';
 export { useOnboardingStore } from './stores/use-onboarding-store';
 
 // Actions
-export { getRandomNickname, registerUser } from './actions/onboarding.actions';
+export { getRandomNickname, registerPreferences, registerUser } from './actions/onboarding.actions';
 
 // Constants
 export * from './constants/onboarding.constants';
 
 // Types
 export type * from './types/onboarding.type';
-export type { CategorySection as OnboardingCategorySection } from './types/onboarding.type';
+export type {
+  CategorySection as OnboardingCategorySection,
+  PreferencesState,
+} from './types/onboarding.type';
 
 // Utils
-export { calculateAge, isBirthValid, validate } from './utils/validation.utils';
+export { calculateAge, isFutureDate, validate } from './utils/validation.utils';
+export { toOptions, toggle } from './utils/preferences.utils';

--- a/apps/web/src/features/onboarding/schemas/__tests__/validation.schemas.test.ts
+++ b/apps/web/src/features/onboarding/schemas/__tests__/validation.schemas.test.ts
@@ -1,0 +1,191 @@
+import {
+  COMMERCE_PREFERENCES,
+  COMMUNITY_PREFERENCES,
+  FEMININE_CARE_PREFERENCES,
+  GYNECOLOGY_PREFERENCES,
+  HEALTH_CARE_PREFERENCES,
+  HOSPITAL_PRIORITIES,
+} from '../../constants/onboarding.constants';
+import { preferencesSchema } from '../validation.schemas';
+
+// ─── Test Data ────────────────────────────────────────────────────────
+function validPreferences() {
+  return {
+    healthCareInterests: [HEALTH_CARE_PREFERENCES[0].id],
+    gynecologyInterests: [GYNECOLOGY_PREFERENCES[0].id],
+    hasVisited: false,
+    hospitalPriorities: [HOSPITAL_PRIORITIES[0].id],
+    communityInterests: [COMMUNITY_PREFERENCES[0].id],
+    commerceInterests: [COMMERCE_PREFERENCES[0].id],
+    productCategories: [FEMININE_CARE_PREFERENCES[0].id],
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────
+describe('preferencesSchema', () => {
+  it('accepts valid preferences data', () => {
+    const result = preferencesSchema.safeParse(validPreferences());
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty arrays for optional sub-section fields', () => {
+    // gynecologyInterests, hospitalPriorities, productCategories are conditionally shown
+    // and may legitimately be empty. Required fields must have at least one value.
+    const data = {
+      healthCareInterests: [HEALTH_CARE_PREFERENCES[0].id],
+      gynecologyInterests: [],
+      hasVisited: true,
+      hospitalPriorities: [],
+      communityInterests: [COMMUNITY_PREFERENCES[0].id],
+      commerceInterests: [COMMERCE_PREFERENCES[0].id],
+      productCategories: [],
+    };
+
+    const result = preferencesSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts all valid IDs for each category', () => {
+    const data = {
+      healthCareInterests: HEALTH_CARE_PREFERENCES.map((i) => i.id),
+      gynecologyInterests: GYNECOLOGY_PREFERENCES.map((i) => i.id),
+      hasVisited: true,
+      hospitalPriorities: HOSPITAL_PRIORITIES.map((i) => i.id),
+      communityInterests: COMMUNITY_PREFERENCES.map((i) => i.id),
+      commerceInterests: COMMERCE_PREFERENCES.map((i) => i.id),
+      productCategories: FEMININE_CARE_PREFERENCES.map((i) => i.id),
+    };
+
+    const result = preferencesSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  // ─── Invalid healthCareInterests ──────────────────────────────────
+  describe('healthCareInterests', () => {
+    it('rejects empty array', () => {
+      const data = { ...validPreferences(), healthCareInterests: [] };
+      const result = preferencesSchema.safeParse(data);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects invalid IDs', () => {
+      const data = { ...validPreferences(), healthCareInterests: ['INVALID_ID'] };
+      const result = preferencesSchema.safeParse(data);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects when field is missing', () => {
+      const { healthCareInterests: _, ...rest } = validPreferences();
+      const result = preferencesSchema.safeParse(rest);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // ─── Invalid gynecologyInterests ──────────────────────────────────
+  describe('gynecologyInterests', () => {
+    it('rejects invalid IDs', () => {
+      const data = { ...validPreferences(), gynecologyInterests: ['NONEXISTENT'] };
+      const result = preferencesSchema.safeParse(data);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // ─── Invalid hospitalPriorities ───────────────────────────────────
+  describe('hospitalPriorities', () => {
+    it('rejects invalid IDs', () => {
+      const data = { ...validPreferences(), hospitalPriorities: ['FAKE_PRIORITY'] };
+      const result = preferencesSchema.safeParse(data);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // ─── Invalid communityInterests ───────────────────────────────────
+  describe('communityInterests', () => {
+    it('rejects empty array', () => {
+      const data = { ...validPreferences(), communityInterests: [] };
+      const result = preferencesSchema.safeParse(data);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects invalid IDs', () => {
+      const data = { ...validPreferences(), communityInterests: ['WRONG'] };
+      const result = preferencesSchema.safeParse(data);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // ─── Invalid commerceInterests ────────────────────────────────────
+  describe('commerceInterests', () => {
+    it('rejects empty array', () => {
+      const data = { ...validPreferences(), commerceInterests: [] };
+      const result = preferencesSchema.safeParse(data);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects invalid IDs', () => {
+      const data = { ...validPreferences(), commerceInterests: ['BOGUS'] };
+      const result = preferencesSchema.safeParse(data);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // ─── Invalid productCategories ────────────────────────────────────
+  describe('productCategories', () => {
+    it('rejects invalid IDs', () => {
+      const data = { ...validPreferences(), productCategories: ['UNKNOWN'] };
+      const result = preferencesSchema.safeParse(data);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // ─── hasVisited ───────────────────────────────────────────────────
+  describe('hasVisited', () => {
+    it('accepts true', () => {
+      const data = { ...validPreferences(), hasVisited: true };
+      const result = preferencesSchema.safeParse(data);
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts false', () => {
+      const data = { ...validPreferences(), hasVisited: false };
+      const result = preferencesSchema.safeParse(data);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects non-boolean values', () => {
+      const data = { ...validPreferences(), hasVisited: 'yes' };
+      const result = preferencesSchema.safeParse(data);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing field', () => {
+      const { hasVisited: _, ...rest } = validPreferences();
+      const result = preferencesSchema.safeParse(rest);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // ─── Mixed invalid ───────────────────────────────────────────────
+  describe('mixed invalid data', () => {
+    it('rejects completely wrong shape', () => {
+      const result = preferencesSchema.safeParse({ foo: 'bar' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects null', () => {
+      const result = preferencesSchema.safeParse(null);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects undefined', () => {
+      const result = preferencesSchema.safeParse(undefined);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects number arrays where string arrays are expected', () => {
+      const data = { ...validPreferences(), healthCareInterests: [123, 456] };
+      const result = preferencesSchema.safeParse(data);
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/features/onboarding/schemas/validation.schemas.ts
+++ b/apps/web/src/features/onboarding/schemas/validation.schemas.ts
@@ -1,10 +1,18 @@
 import { z } from 'zod';
 
-import { isBirthValid } from '../utils/validation.utils';
+import {
+  COMMERCE_PREFERENCES,
+  COMMUNITY_PREFERENCES,
+  FEMININE_CARE_PREFERENCES,
+  GYNECOLOGY_PREFERENCES,
+  HEALTH_CARE_PREFERENCES,
+  HOSPITAL_PRIORITIES,
+} from '../constants/onboarding.constants';
+import { isFutureDate } from '../utils/validation.utils';
 
 export const NICKNAME_REGEX = /^[a-zA-Z0-9_\-\uAC00-\uD7A3]+$/;
 
-// --- nickname ---
+// --- nickname schema ---
 export const nicknameSchema = z
   .string()
   .min(1, '닉네임을 입력해주세요.')
@@ -14,7 +22,7 @@ export const nicknameSchema = z
   .regex(NICKNAME_REGEX, '특수문자는 밑줄(_)과 하이픈(-)만 포함할 수 있습니다.');
 
 // --- age schema ---
-export const ageSchema = z.number();
+export const ageSchema = z.number().int().min(0).max(150);
 
 // --- birthdate selection schema ---
 export const birthdateSelectionSchema = z
@@ -25,8 +33,56 @@ export const birthdateSelectionSchema = z
   })
   .refine(({ year, month, day }) => {
     if (!year || !month || !day) return true;
-    return !isBirthValid(parseInt(year, 10), parseInt(month, 10), parseInt(day, 10));
+    return !isFutureDate(parseInt(year, 10), parseInt(month, 10), parseInt(day, 10));
   }, '유효한 생년월일을 선택해주세요.');
+
+// --- preferences schema ---
+const healthCareIds = HEALTH_CARE_PREFERENCES.map((i) => i.id);
+const gynecologyIds = GYNECOLOGY_PREFERENCES.map((i) => i.id);
+const hospitalPriorityIds = HOSPITAL_PRIORITIES.map((i) => i.id);
+const communityIds = COMMUNITY_PREFERENCES.map((i) => i.id);
+const commerceIds = COMMERCE_PREFERENCES.map((i) => i.id);
+const feminineCareIds = FEMININE_CARE_PREFERENCES.map((i) => i.id);
+
+export const preferencesSchema = z.object({
+  healthCareInterests: z
+    .array(z.string())
+    .min(1, '최소 1개의 HealthCare 관심사를 선택해주세요.')
+    .refine(
+      (arr) => arr.every((v) => healthCareIds.includes(v)),
+      '잘못된 HealthCare 관심사 값입니다.',
+    ),
+  gynecologyInterests: z
+    .array(z.string())
+    .refine(
+      (arr) => arr.every((v) => gynecologyIds.includes(v)),
+      '잘못된 여성 의학 관심사 값입니다.',
+    ),
+  hasVisited: z.boolean(),
+  hospitalPriorities: z
+    .array(z.string())
+    .refine(
+      (arr) => arr.every((v) => hospitalPriorityIds.includes(v)),
+      '잘못된 병원 우선순위 값입니다.',
+    ),
+  communityInterests: z
+    .array(z.string())
+    .min(1, '최소 1개의 Community 관심사를 선택해주세요.')
+    .refine(
+      (arr) => arr.every((v) => communityIds.includes(v)),
+      '잘못된 Community 관심사 값입니다.',
+    ),
+  commerceInterests: z
+    .array(z.string())
+    .min(1, '최소 1개의 Commerce 관심사를 선택해주세요.')
+    .refine((arr) => arr.every((v) => commerceIds.includes(v)), '잘못된 Commerce 관심사 값입니다.'),
+  productCategories: z
+    .array(z.string())
+    .refine(
+      (arr) => arr.every((v) => feminineCareIds.includes(v)),
+      '잘못된 여성용품 카테고리 값입니다.',
+    ),
+});
 
 // --- onboarding form schema ---
 export const onboardingFormSchema = z.object({

--- a/apps/web/src/features/onboarding/stores/__tests__/use-onboarding-store.test.ts
+++ b/apps/web/src/features/onboarding/stores/__tests__/use-onboarding-store.test.ts
@@ -1,0 +1,246 @@
+import { act } from '@testing-library/react';
+
+import { ErrorCode } from '@repo/shared/types';
+
+import { registerPreferences } from '../../actions/onboarding.actions';
+import type { PreferencesRequest } from '../../types/onboarding.type';
+import { useOnboardingStore } from '../use-onboarding-store';
+
+// ─── Mocks ────────────────────────────────────────────────────────────
+jest.mock('../../actions/onboarding.actions', () => ({
+  registerPreferences: jest.fn(),
+}));
+
+jest.mock('@repo/shared/utils', () => ({
+  logger: {
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  },
+  isLocalStorageAvailable: jest.fn(() => false),
+}));
+
+const mockedRegisterPreferences = registerPreferences as jest.MockedFunction<
+  typeof registerPreferences
+>;
+
+// ─── Test Data ────────────────────────────────────────────────────────
+const mockPreferencesRequest: PreferencesRequest = {
+  healthCareInterests: ['GYNECOLOGY_QNA'],
+  gynecologyInterests: ['MENSTRUAL_PAIN'],
+  hasVisited: false,
+  hospitalPriorities: ['FEMALE_DOCTOR'],
+  communityInterests: ['COMMUNITY'],
+  commerceInterests: ['PRODUCT_SEARCH'],
+  productCategories: ['TAMPON'],
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────
+describe('useOnboardingStore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset store to initial state
+    act(() => {
+      useOnboardingStore.getState().resetOnboarding();
+    });
+  });
+
+  describe('initial state', () => {
+    it('has empty nickname', () => {
+      expect(useOnboardingStore.getState().nickname).toBe('');
+    });
+
+    it('has age 0', () => {
+      expect(useOnboardingStore.getState().age).toBe(0);
+    });
+
+    it('has empty birthDateSelection', () => {
+      expect(useOnboardingStore.getState().birthDateSelection).toEqual({
+        year: '',
+        month: '',
+        day: '',
+      });
+    });
+
+    it('has empty preferences', () => {
+      expect(useOnboardingStore.getState().preferences).toEqual({
+        healthCareInterests: [],
+        gynecologyInterests: [],
+        hasVisited: null,
+        hospitalPriorities: [],
+        communityInterests: [],
+        commerceInterests: [],
+        productCategories: [],
+      });
+    });
+  });
+
+  describe('setNickname', () => {
+    it('updates the nickname', () => {
+      act(() => {
+        useOnboardingStore.getState().setNickname('luna');
+      });
+      expect(useOnboardingStore.getState().nickname).toBe('luna');
+    });
+  });
+
+  describe('setAge', () => {
+    it('updates the age', () => {
+      act(() => {
+        useOnboardingStore.getState().setAge(25);
+      });
+      expect(useOnboardingStore.getState().age).toBe(25);
+    });
+  });
+
+  describe('setPreferences', () => {
+    it('partially updates preferences', () => {
+      act(() => {
+        useOnboardingStore.getState().setPreferences({ healthCareInterests: ['GYNECOLOGY_QNA'] });
+      });
+      const { preferences } = useOnboardingStore.getState();
+      expect(preferences.healthCareInterests).toEqual(['GYNECOLOGY_QNA']);
+      expect(preferences.communityInterests).toEqual([]);
+    });
+
+    it('does not overwrite unrelated fields', () => {
+      act(() => {
+        useOnboardingStore.getState().setPreferences({ communityInterests: ['COMMUNITY'] });
+        useOnboardingStore.getState().setPreferences({ commerceInterests: ['PRODUCT_SEARCH'] });
+      });
+      const { preferences } = useOnboardingStore.getState();
+      expect(preferences.communityInterests).toEqual(['COMMUNITY']);
+      expect(preferences.commerceInterests).toEqual(['PRODUCT_SEARCH']);
+    });
+  });
+
+  describe('setBirthDateSelection', () => {
+    it('updates the birth date selection', () => {
+      const selection = { year: '2000', month: '06', day: '15' };
+      act(() => {
+        useOnboardingStore.getState().setBirthDateSelection(selection);
+      });
+      expect(useOnboardingStore.getState().birthDateSelection).toEqual(selection);
+    });
+  });
+
+  describe('resetOnboarding', () => {
+    it('resets all state to initial values', () => {
+      act(() => {
+        useOnboardingStore.getState().setNickname('test');
+        useOnboardingStore.getState().setAge(30);
+        useOnboardingStore.getState().setBirthDateSelection({
+          year: '1990',
+          month: '01',
+          day: '01',
+        });
+      });
+
+      act(() => {
+        useOnboardingStore.getState().resetOnboarding();
+      });
+
+      const state = useOnboardingStore.getState();
+      expect(state.nickname).toBe('');
+      expect(state.age).toBe(0);
+      expect(state.birthDateSelection).toEqual({ year: '', month: '', day: '' });
+      expect(state.preferences).toEqual({
+        healthCareInterests: [],
+        gynecologyInterests: [],
+        hasVisited: null,
+        hospitalPriorities: [],
+        communityInterests: [],
+        commerceInterests: [],
+        productCategories: [],
+      });
+    });
+  });
+
+  describe('submitPreferences', () => {
+    it('calls registerPreferences action and resets store on success', async () => {
+      mockedRegisterPreferences.mockResolvedValue({
+        success: true,
+        data: 'OK',
+      });
+
+      // Set some state first
+      act(() => {
+        useOnboardingStore.getState().setNickname('testuser');
+        useOnboardingStore.getState().setAge(25);
+      });
+
+      await act(async () => {
+        await useOnboardingStore.getState().submitPreferences(mockPreferencesRequest);
+      });
+
+      expect(mockedRegisterPreferences).toHaveBeenCalledWith(mockPreferencesRequest);
+
+      // Store should be reset to initial state
+      const state = useOnboardingStore.getState();
+      expect(state.nickname).toBe('');
+      expect(state.age).toBe(0);
+    });
+
+    it('throws error when registerPreferences returns failure', async () => {
+      mockedRegisterPreferences.mockResolvedValue({
+        success: false,
+        error: {
+          code: ErrorCode.VALIDATION_ERROR,
+          message: '잘못된 요청입니다.',
+        },
+      });
+
+      await expect(
+        act(async () => {
+          await useOnboardingStore.getState().submitPreferences(mockPreferencesRequest);
+        }),
+      ).rejects.toThrow('잘못된 요청입니다.');
+    });
+
+    it('throws error with default message when error message is absent', async () => {
+      mockedRegisterPreferences.mockResolvedValue({
+        success: false,
+        error: undefined,
+      });
+
+      await expect(
+        act(async () => {
+          await useOnboardingStore.getState().submitPreferences(mockPreferencesRequest);
+        }),
+      ).rejects.toThrow('오류가 발생했습니다.');
+    });
+
+    it('does not reset store when registerPreferences fails', async () => {
+      mockedRegisterPreferences.mockResolvedValue({
+        success: false,
+        error: { code: ErrorCode.UNKNOWN_ERROR, message: 'fail' },
+      });
+
+      act(() => {
+        useOnboardingStore.getState().setNickname('keepme');
+      });
+
+      try {
+        await act(async () => {
+          await useOnboardingStore.getState().submitPreferences(mockPreferencesRequest);
+        });
+      } catch {
+        // expected
+      }
+
+      // State should NOT be reset
+      expect(useOnboardingStore.getState().nickname).toBe('keepme');
+    });
+
+    it('propagates errors thrown by registerPreferences', async () => {
+      mockedRegisterPreferences.mockRejectedValue(new Error('Network failure'));
+
+      await expect(
+        act(async () => {
+          await useOnboardingStore.getState().submitPreferences(mockPreferencesRequest);
+        }),
+      ).rejects.toThrow('Network failure');
+    });
+  });
+});

--- a/apps/web/src/features/onboarding/stores/use-onboarding-store.ts
+++ b/apps/web/src/features/onboarding/stores/use-onboarding-store.ts
@@ -3,25 +3,38 @@ import { createJSONStorage, persist } from 'zustand/middleware';
 
 import { isLocalStorageAvailable, logger } from '@repo/shared/utils';
 
-import type { BirthDateSelection, OnboardingState } from '../types/onboarding.type';
+import { registerPreferences } from '../actions/onboarding.actions';
+import type {
+  BirthDateSelection,
+  OnboardingState,
+  PreferencesRequest,
+  PreferencesState,
+} from '../types/onboarding.type';
 
 interface OnboardingStoreState extends OnboardingState {
   setNickname: (nickname: string) => void;
   setAge: (age: number) => void;
   setBirthDateSelection: (birthDateSelection: BirthDateSelection) => void;
+  setPreferences: (update: Partial<PreferencesState>) => void;
   resetOnboarding: () => void;
+  submitPreferences: (data: PreferencesRequest) => Promise<void>;
 }
 
-const initialState: Omit<
-  OnboardingState,
-  keyof Pick<
-    OnboardingStoreState,
-    'setNickname' | 'setAge' | 'setBirthDateSelection' | 'resetOnboarding'
-  >
-> = {
+const initialPreferences: PreferencesState = {
+  healthCareInterests: [],
+  gynecologyInterests: [],
+  hasVisited: null,
+  hospitalPriorities: [],
+  communityInterests: [],
+  commerceInterests: [],
+  productCategories: [],
+};
+
+const initialState: OnboardingState = {
   nickname: '',
   age: 0,
   birthDateSelection: { year: '', month: '', day: '' },
+  preferences: initialPreferences,
 };
 
 export const useOnboardingStore = create<OnboardingStoreState>()(
@@ -32,7 +45,16 @@ export const useOnboardingStore = create<OnboardingStoreState>()(
       setNickname: (nickname) => set({ nickname }),
       setAge: (age) => set({ age }),
       setBirthDateSelection: (birthDateSelection) => set({ birthDateSelection }),
+      setPreferences: (update) =>
+        set((state) => ({ preferences: { ...state.preferences, ...update } })),
       resetOnboarding: () => set(initialState),
+      submitPreferences: async (data: PreferencesRequest) => {
+        const response = await registerPreferences(data);
+        if (!response.success) {
+          throw new Error(response.error?.message || '오류가 발생했습니다.');
+        }
+        set(initialState);
+      },
     }),
     {
       name: 'onboarding-storage',
@@ -41,11 +63,13 @@ export const useOnboardingStore = create<OnboardingStoreState>()(
         nickname: state.nickname,
         age: state.age,
         birthDateSelection: state.birthDateSelection,
+        preferences: state.preferences,
       }),
       onRehydrateStorage: () => (state) => {
         if (state) {
           logger.info('[OnboardingStore] Rehydrated from storage:', {
             nickname: state.nickname,
+            age: state.age,
           });
         } else {
           logger.warn('[OnboardingStore] Failed to rehydrate from storage');

--- a/apps/web/src/features/onboarding/types/onboarding.type.ts
+++ b/apps/web/src/features/onboarding/types/onboarding.type.ts
@@ -19,10 +19,21 @@ export interface OptionGroup {
   colorScheme?: ButtonColorScheme;
 }
 
+export interface PreferencesState {
+  healthCareInterests: string[];
+  gynecologyInterests: string[];
+  hasVisited: boolean | null;
+  hospitalPriorities: string[];
+  communityInterests: string[];
+  commerceInterests: string[];
+  productCategories: string[];
+}
+
 export interface OnboardingState {
   nickname: string;
   age: number;
   birthDateSelection: BirthDateSelection;
+  preferences: PreferencesState;
 }
 
 export interface SubmitRequest {
@@ -32,4 +43,14 @@ export interface SubmitRequest {
 
 export interface SubmitResponse {
   nickname: string;
+}
+
+export interface PreferencesRequest {
+  healthCareInterests: string[];
+  gynecologyInterests: string[];
+  hasVisited: boolean;
+  hospitalPriorities: string[];
+  communityInterests: string[];
+  commerceInterests: string[];
+  productCategories: string[];
 }

--- a/apps/web/src/features/onboarding/utils/__tests__/preferences.utils.test.ts
+++ b/apps/web/src/features/onboarding/utils/__tests__/preferences.utils.test.ts
@@ -1,0 +1,81 @@
+import { toggle, toOptions } from '../preferences.utils';
+
+// ─── toOptions ────────────────────────────────────────────────────────
+describe('toOptions', () => {
+  it('converts items with id/label to key/display format', () => {
+    const items = [
+      { id: 'A', label: 'Alpha' },
+      { id: 'B', label: 'Beta' },
+    ];
+
+    expect(toOptions(items)).toEqual([
+      { key: 'A', display: 'Alpha' },
+      { key: 'B', display: 'Beta' },
+    ]);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(toOptions([])).toEqual([]);
+  });
+
+  it('preserves order of items', () => {
+    const items = [
+      { id: 'C', label: 'Charlie' },
+      { id: 'A', label: 'Alpha' },
+      { id: 'B', label: 'Beta' },
+    ];
+
+    const result = toOptions(items);
+    expect(result.map((o) => o.key)).toEqual(['C', 'A', 'B']);
+  });
+
+  it('handles items with special characters in label', () => {
+    const items = [{ id: 'SPECIAL', label: '여성 의학 궁금증 해결' }];
+    const result = toOptions(items);
+    expect(result[0].display).toBe('여성 의학 궁금증 해결');
+  });
+
+  it('does not mutate the original array', () => {
+    const items = [{ id: 'A', label: 'Alpha' }];
+    const original = [...items];
+    toOptions(items);
+    expect(items).toEqual(original);
+  });
+});
+
+// ─── toggle ───────────────────────────────────────────────────────────
+describe('toggle', () => {
+  it('appends value when not present', () => {
+    expect(toggle([], 'A')).toEqual(['A']);
+    expect(toggle(['B'], 'A')).toEqual(['B', 'A']);
+  });
+
+  it('removes value when already present', () => {
+    expect(toggle(['A', 'B'], 'A')).toEqual(['B']);
+    expect(toggle(['A'], 'A')).toEqual([]);
+  });
+
+  it('does not mutate the original array', () => {
+    const original = ['A', 'B'];
+    const copy = [...original];
+    toggle(original, 'A');
+    expect(original).toEqual(copy);
+  });
+
+  it('handles duplicate values in source array (removes all matches)', () => {
+    // filter removes all matching values
+    expect(toggle(['A', 'A', 'B'], 'A')).toEqual(['B']);
+  });
+
+  it('handles empty string value', () => {
+    expect(toggle([], '')).toEqual(['']);
+    expect(toggle([''], '')).toEqual([]);
+  });
+
+  it('is idempotent - toggling twice returns original', () => {
+    const arr = ['A', 'B'];
+    const afterAdd = toggle(arr, 'C');
+    const afterRemove = toggle(afterAdd, 'C');
+    expect(afterRemove).toEqual(arr);
+  });
+});

--- a/apps/web/src/features/onboarding/utils/__tests__/validation.utils.test.ts
+++ b/apps/web/src/features/onboarding/utils/__tests__/validation.utils.test.ts
@@ -1,0 +1,117 @@
+import { z } from 'zod';
+
+import { calculateAge, isFutureDate, validate } from '../validation.utils';
+
+// ─── isFutureDate ─────────────────────────────────────────────────────
+describe('isFutureDate', () => {
+  const today = new Date();
+
+  it('returns true for today', () => {
+    expect(isFutureDate(today.getFullYear(), today.getMonth() + 1, today.getDate())).toBe(true);
+  });
+
+  it('returns true for a future date', () => {
+    expect(isFutureDate(today.getFullYear() + 1, 1, 1)).toBe(true);
+  });
+
+  it('returns false for a past date', () => {
+    expect(isFutureDate(1990, 6, 15)).toBe(false);
+  });
+
+  it('returns false for yesterday', () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    expect(
+      isFutureDate(yesterday.getFullYear(), yesterday.getMonth() + 1, yesterday.getDate()),
+    ).toBe(false);
+  });
+});
+
+// ─── calculateAge ─────────────────────────────────────────────────────
+describe('calculateAge', () => {
+  const today = new Date();
+  const currentYear = today.getFullYear();
+  const currentMonth = today.getMonth() + 1;
+  const currentDay = today.getDate();
+
+  it('returns correct age when birthday has already passed this year', () => {
+    const birthYear = currentYear - 30;
+    // Use January 1 to ensure it has passed for any test run date
+    const age = calculateAge(birthYear, 1, 1);
+    expect(age).toBe(30);
+  });
+
+  it('returns correct age when birthday has NOT yet passed this year', () => {
+    const birthYear = currentYear - 25;
+    // Use December 31 — has not passed unless today is Dec 31
+    if (currentMonth < 12 || currentDay < 31) {
+      const age = calculateAge(birthYear, 12, 31);
+      expect(age).toBe(24);
+    }
+  });
+
+  it('returns 0 for a newborn (born today)', () => {
+    const age = calculateAge(currentYear, currentMonth, currentDay);
+    expect(age).toBe(0);
+  });
+
+  it('handles year boundary correctly', () => {
+    // Person born Jan 2, previous year, tested on Jan 1 of this year → age is still 0
+    const birthYear = currentYear - 1;
+    const age = calculateAge(birthYear, 1, 2);
+    if (currentMonth === 1 && currentDay === 1) {
+      expect(age).toBe(0);
+    } else {
+      expect(age).toBe(1);
+    }
+  });
+});
+
+// ─── validate ─────────────────────────────────────────────────────────
+describe('validate', () => {
+  const minSchema = z.string().min(3, '3자 이상 입력하세요.');
+  const maxSchema = z.string().max(10, '10자 이하로 입력하세요.');
+
+  it('returns isValid=true for valid input with single schema', () => {
+    const result = validate('hello', minSchema);
+    expect(result.isValid).toBe(true);
+    expect(result.error).toBeNull();
+  });
+
+  it('returns isValid=false with error message for invalid input', () => {
+    const result = validate('ab', minSchema);
+    expect(result.isValid).toBe(false);
+    expect(result.error).toBe('3자 이상 입력하세요.');
+  });
+
+  it('validates against multiple schemas sequentially', () => {
+    const result = validate('hello', [minSchema, maxSchema]);
+    expect(result.isValid).toBe(true);
+    expect(result.error).toBeNull();
+  });
+
+  it('stops at first failing schema and returns its error', () => {
+    const result = validate('ab', [minSchema, maxSchema]);
+    expect(result.isValid).toBe(false);
+    expect(result.error).toBe('3자 이상 입력하세요.');
+  });
+
+  it('catches the second schema error when first passes', () => {
+    const longString = 'this_is_over_ten_chars';
+    const result = validate(longString, [minSchema, maxSchema]);
+    expect(result.isValid).toBe(false);
+    expect(result.error).toBe('10자 이하로 입력하세요.');
+  });
+
+  it('handles non-ZodError by returning generic error message', () => {
+    const throwingSchema = {
+      parse: () => {
+        throw new Error('unexpected');
+      },
+    } as unknown as z.ZodType<string>;
+
+    const result = validate('test', throwingSchema);
+    expect(result.isValid).toBe(false);
+    expect(result.error).toBe('An unknown error occurred.');
+  });
+});

--- a/apps/web/src/features/onboarding/utils/preferences.utils.ts
+++ b/apps/web/src/features/onboarding/utils/preferences.utils.ts
@@ -1,0 +1,11 @@
+// convert items to { key, display } format for SelectionGroup
+export function toOptions(
+  items: { id: string; label: string }[],
+): { key: string; display: string }[] {
+  return items.map((i) => ({ key: i.id, display: i.label }));
+}
+
+// toggle presence of value in array (for multi-select)
+export function toggle(arr: string[], value: string): string[] {
+  return arr.includes(value) ? arr.filter((v) => v !== value) : [...arr, value];
+}

--- a/apps/web/src/features/onboarding/utils/validation.utils.ts
+++ b/apps/web/src/features/onboarding/utils/validation.utils.ts
@@ -9,7 +9,7 @@ export interface ValidationResult {
   isLoading?: boolean;
 }
 
-export function isBirthValid(year: number, month: number, day: number): boolean {
+export function isFutureDate(year: number, month: number, day: number): boolean {
   const birthDate = new Date(year, month - 1, day);
   const today = new Date();
   today.setHours(0, 0, 0, 0);

--- a/packages/shared/src/constants/routes.ts
+++ b/packages/shared/src/constants/routes.ts
@@ -7,7 +7,7 @@ export const ROUTES = {
   // Onboarding
   ONBOARDING_NAME: '/onboarding/name',
   ONBOARDING_AGE: '/onboarding/age',
-  ONBOARDING_INTERESTS: '/onboarding/interests',
+  ONBOARDING_PREFERENCES: '/onboarding/preferences',
 
   // Shopping
   RANKING: '/ranking',


### PR DESCRIPTION
## 🧹 Overview

**Summary:**

- #76 - Onboarding: nickname and age page
- #78 - Onboarding missing code additions
- #81 - Nickname page import fix
- #84 - Register API response unsrap
- #86 - Complete onboarding flow(preferences)

---

## 🧩 Change Scope

- [x] Config / Build setup
- [ ] Dependency update
- [ ] CI/CD / Workflow
- [ ] Script / Command
- [x] UI/UX
- [x] Code formatting or lint rules

---

## 📦 Included PRs


#76 · feat(onboarding): add nickname and age page

- 닉네임 입력 페이지 구현
- 나이 입력 페이지 구현 (한국식 나이 계산 포함)
- starter-kit에 star-rating 컴포넌트 및 아이콘 추가  


#78 · chore: add missing codes for onboarding

- 온보딩 플로우에 누락된 코드 추가
- auth actions 미사용 import 정리

#81 · chore: fix import from nickname page

- 닉네임 페이지 import 경로 수정  


#84 · chore(onboarding): unwrap register api response

- registerPreferencesAPI 응답 언래핑 처리  


#86 · feat(onboarding): complete onboarding flow

- 선호도 선택 페이지 구현 (SelectionGroup 컴포넌트 활용, 다중 선택 UI)
- registerPreferences server action 추가
- useAnimatedSection 훅 및 preferences 유틸리티 추가
- 완료 항목 수에 따른 동적 submit 버튼 배경색
- withAuth 적용 및 가드 메시지 다국어화
- 온보딩 전체 테스트 스위트 추가
- ARIA 접근성 속성 추가  


---

## 🧪 Validation

- [x] `pnpm build` passes
- [x] `pnpm check` (lint + format + test) passes
- [x] Config or script works as expected
- [x] No runtime behavior changed

---

## ⚠️ Breaking Changes

- [x] None
- [ ] Yes (describe below)

---

## ✅ Final Checklist

- [x] Commit message follows convention
- [x] PR title is clear
- [x] Code formatted & linted
- [x] No unnecessary logs
- [x] Ready to merge 🚀