### PR TITLE
fix: fix navigation guard and add auth protection'

### DIFF
--- a/apps/web/src/app/[locale]/onboarding/age/page.tsx
+++ b/apps/web/src/app/[locale]/onboarding/age/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useCallback, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useCallback, useState } from 'react';
 
 import { ROUTES } from '@repo/shared/constants';
 import { logger, transformError } from '@repo/shared/utils';
@@ -11,9 +11,10 @@ import { toast } from '@web/components/ui/toast';
 import { withAuth } from '@web/features/auth';
 import {
   ERROR_MESSAGES,
-  registerUser,
+  registerUserAPI,
   Title,
   useBirthdateValidation,
+  useOnboardingNavigationGuard,
   useOnboardingStore,
 } from '@web/features/onboarding';
 
@@ -25,6 +26,8 @@ function AgePage() {
   const [isDateValid, setIsDateValid] = useState(false);
 
   const nickname = useOnboardingStore((s) => s.nickname);
+
+  useOnboardingNavigationGuard({ requireNickname: true, nickname });
 
   const { birthDateSelection, error, handleDateChange, validateBirthdate } =
     useBirthdateValidation();
@@ -43,12 +46,7 @@ function AgePage() {
 
         logger.info('[Age Page] Submitting user:', { nickname, age });
 
-        const response = await registerUser({ chatNickname: nickname, age });
-
-        if (!response.success) {
-          toast.error(response.error?.message || ERROR_MESSAGES.GENERIC);
-          return;
-        }
+        await registerUserAPI({ chatNickname: nickname, age });
 
         router.push(ROUTES.ONBOARDING_PREFERENCES);
       } catch (error) {

--- a/apps/web/src/app/[locale]/onboarding/name/page.tsx
+++ b/apps/web/src/app/[locale]/onboarding/name/page.tsx
@@ -9,21 +9,31 @@ import { Input } from '@web/components/ui/input';
 import { Spinner } from '@web/components/ui/spinner';
 import { Title, useNicknameValidation } from '@web/features/onboarding';
 import { getRandomNicknameAPI } from '@web/features/onboarding/api/onboarding.api';
+import { useOnboardingStore } from '@web/features/onboarding/stores/use-onboarding-store';
 
 import styles from '../onboarding.module.scss';
-
-const MOCK_RANDOM_NICKNAME = 'LUNA1234';
 
 function NamePage() {
   const router = useRouter();
   const [randomNickname, setRandomNickname] = useState<string | null>(null);
   const { nickname: name, handleNicknameChange, validateNickname, error } = useNicknameValidation();
 
+  const storedNickname = useOnboardingStore((s) => s.nickname);
+  const storedAge = useOnboardingStore((s) => s.age);
+
+  useEffect(() => {
+    if (storedNickname && storedAge) {
+      router.replace(ROUTES.ONBOARDING_PREFERENCES);
+    } else if (storedNickname) {
+      router.replace(ROUTES.ONBOARDING_AGE);
+    }
+  }, [storedNickname, storedAge, router]);
+
   // get random nickname (account ID)
   useEffect(() => {
     getRandomNicknameAPI()
       .then((randomNick) => setRandomNickname(randomNick))
-      .catch(() => setRandomNickname(MOCK_RANDOM_NICKNAME));
+      .catch(() => setRandomNickname(null));
   }, []);
 
   const handleSubmit = useCallback(
@@ -60,11 +70,6 @@ function NamePage() {
           aria-invalid={!!error}
           aria-describedby={error ? 'nickname-error' : undefined}
         />
-        {error && (
-          <span id="nickname-error" role="alert" className={styles.errorHint}>
-            {error}
-          </span>
-        )}
 
         <span>
           상품 리뷰 등에 사용될 {name}님의 아이디는 {randomNickname}(으)로 할게요.

--- a/apps/web/src/app/[locale]/onboarding/onboarding.module.scss
+++ b/apps/web/src/app/[locale]/onboarding/onboarding.module.scss
@@ -31,7 +31,6 @@ $border-width: 2px;
   }
 
   %submit-base {
-    width: 10%;
     color: black !important;
     font-size: $font-size-lg;
     font-weight: $font-weight-medium;
@@ -39,20 +38,23 @@ $border-width: 2px;
     box-shadow: $box-shadow-md;
     z-index: 10;
     bottom: calc(1.5rem + env(safe-area-inset-bottom));
-
-    @include respond(mobile) {
-      width: 36%;
-    }
   }
 
   .submit {
     @extend %submit-base;
     position: fixed;
-    left: 50%;
-    transform: translateX(-50%);
+    left: 0;
+    right: 0;
+    margin: 0 auto;
+    width: 56%;
+    transition: transform 0.1s ease;
+
+    @include respond(mobile) {
+      width: 33%;
+    }
 
     &:active {
-      transform: translateX(-50%) translateY(1px);
+      transform: translateY(2px);
     }
   }
 
@@ -60,6 +62,11 @@ $border-width: 2px;
     @extend %submit-base;
     position: sticky;
     align-self: center;
+    width: 10%;
+
+    @include respond(mobile) {
+      width: 36%;
+    }
 
     &:active {
       transform: translateY(1px);

--- a/apps/web/src/features/onboarding/index.ts
+++ b/apps/web/src/features/onboarding/index.ts
@@ -17,6 +17,9 @@ export { useOnboardingStore } from './stores/use-onboarding-store';
 // Actions
 export { getRandomNickname, registerPreferences, registerUser } from './actions/onboarding.actions';
 
+// API
+export { registerPreferencesAPI, registerUserAPI } from './api/onboarding.api';
+
 // Constants
 export * from './constants/onboarding.constants';
 

--- a/apps/web/src/features/onboarding/stores/__tests__/use-onboarding-store.test.ts
+++ b/apps/web/src/features/onboarding/stores/__tests__/use-onboarding-store.test.ts
@@ -1,14 +1,12 @@
 import { act } from '@testing-library/react';
 
-import { ErrorCode } from '@repo/shared/types';
-
-import { registerPreferences } from '../../actions/onboarding.actions';
+import { registerPreferencesAPI } from '../../api/onboarding.api';
 import type { PreferencesRequest } from '../../types/onboarding.type';
 import { useOnboardingStore } from '../use-onboarding-store';
 
 // ─── Mocks ────────────────────────────────────────────────────────────
-jest.mock('../../actions/onboarding.actions', () => ({
-  registerPreferences: jest.fn(),
+jest.mock('../../api/onboarding.api', () => ({
+  registerPreferencesAPI: jest.fn(),
 }));
 
 jest.mock('@repo/shared/utils', () => ({
@@ -21,8 +19,8 @@ jest.mock('@repo/shared/utils', () => ({
   isLocalStorageAvailable: jest.fn(() => false),
 }));
 
-const mockedRegisterPreferences = registerPreferences as jest.MockedFunction<
-  typeof registerPreferences
+const mockedRegisterPreferencesAPI = registerPreferencesAPI as jest.MockedFunction<
+  typeof registerPreferencesAPI
 >;
 
 // ─── Test Data ────────────────────────────────────────────────────────
@@ -158,13 +156,9 @@ describe('useOnboardingStore', () => {
   });
 
   describe('submitPreferences', () => {
-    it('calls registerPreferences action and resets store on success', async () => {
-      mockedRegisterPreferences.mockResolvedValue({
-        success: true,
-        data: 'OK',
-      });
+    it('calls registerPreferencesAPI and resets store on success', async () => {
+      mockedRegisterPreferencesAPI.mockResolvedValue('OK');
 
-      // Set some state first
       act(() => {
         useOnboardingStore.getState().setNickname('testuser');
         useOnboardingStore.getState().setAge(25);
@@ -174,48 +168,15 @@ describe('useOnboardingStore', () => {
         await useOnboardingStore.getState().submitPreferences(mockPreferencesRequest);
       });
 
-      expect(mockedRegisterPreferences).toHaveBeenCalledWith(mockPreferencesRequest);
+      expect(mockedRegisterPreferencesAPI).toHaveBeenCalledWith(mockPreferencesRequest);
 
-      // Store should be reset to initial state
       const state = useOnboardingStore.getState();
       expect(state.nickname).toBe('');
       expect(state.age).toBe(0);
     });
 
-    it('throws error when registerPreferences returns failure', async () => {
-      mockedRegisterPreferences.mockResolvedValue({
-        success: false,
-        error: {
-          code: ErrorCode.VALIDATION_ERROR,
-          message: '잘못된 요청입니다.',
-        },
-      });
-
-      await expect(
-        act(async () => {
-          await useOnboardingStore.getState().submitPreferences(mockPreferencesRequest);
-        }),
-      ).rejects.toThrow('잘못된 요청입니다.');
-    });
-
-    it('throws error with default message when error message is absent', async () => {
-      mockedRegisterPreferences.mockResolvedValue({
-        success: false,
-        error: undefined,
-      });
-
-      await expect(
-        act(async () => {
-          await useOnboardingStore.getState().submitPreferences(mockPreferencesRequest);
-        }),
-      ).rejects.toThrow('오류가 발생했습니다.');
-    });
-
-    it('does not reset store when registerPreferences fails', async () => {
-      mockedRegisterPreferences.mockResolvedValue({
-        success: false,
-        error: { code: ErrorCode.UNKNOWN_ERROR, message: 'fail' },
-      });
+    it('does not reset store when registerPreferencesAPI fails', async () => {
+      mockedRegisterPreferencesAPI.mockRejectedValue(new Error('fail'));
 
       act(() => {
         useOnboardingStore.getState().setNickname('keepme');
@@ -229,12 +190,11 @@ describe('useOnboardingStore', () => {
         // expected
       }
 
-      // State should NOT be reset
       expect(useOnboardingStore.getState().nickname).toBe('keepme');
     });
 
-    it('propagates errors thrown by registerPreferences', async () => {
-      mockedRegisterPreferences.mockRejectedValue(new Error('Network failure'));
+    it('propagates errors thrown by registerPreferencesAPI', async () => {
+      mockedRegisterPreferencesAPI.mockRejectedValue(new Error('Network failure'));
 
       await expect(
         act(async () => {

--- a/apps/web/src/features/onboarding/stores/use-onboarding-store.ts
+++ b/apps/web/src/features/onboarding/stores/use-onboarding-store.ts
@@ -3,7 +3,7 @@ import { createJSONStorage, persist } from 'zustand/middleware';
 
 import { isLocalStorageAvailable, logger } from '@repo/shared/utils';
 
-import { registerPreferences } from '../actions/onboarding.actions';
+import { registerPreferencesAPI } from '../api/onboarding.api';
 import type {
   BirthDateSelection,
   OnboardingState,
@@ -49,10 +49,7 @@ export const useOnboardingStore = create<OnboardingStoreState>()(
         set((state) => ({ preferences: { ...state.preferences, ...update } })),
       resetOnboarding: () => set(initialState),
       submitPreferences: async (data: PreferencesRequest) => {
-        const response = await registerPreferences(data);
-        if (!response.success) {
-          throw new Error(response.error?.message || '오류가 발생했습니다.');
-        }
+        await registerPreferencesAPI(data);
         set(initialState);
       },
     }),


### PR DESCRIPTION
## 🐛 Overview

**Summary:**

Navigation guards were not enforced on onboarding step pages, allowing users to directly access any step URL without completing prior steps. Additionally, `withAuth` was commented out across all onboarding pages, leaving them accessible to unauthenticated users.

---

## 🔧 Fix Scope

- [ ] Logic/Business Rules
- [ ] UI/UX
- [x] API Handling
- [x] State Management
- [ ] Dependency Update
- [ ] Error Handling
- [x] Test Update

---

## 🧪 Testing

- [x] Bug reproduced before fix
- [x] Verified fix locally
- [x] `pnpm build` passes
- [x] `pnpm check` (lint + format + test) passes
- [x] No new issues introduced

---

## ⚠️ Regression & Impact

- [x] No regression detected
- [ ] Potential side effects reviewed

## **Details:**

---

## ✅ Final Checklist

- [x] Commit message follows convention
- [x] PR title is clear
- [x] All tests passed
- [x] Code formatted & linted
- [x] No unnecessary logs
- [x] Ready to merge 🚀
